### PR TITLE
option to disable forcebuild for easier development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project( VIAME )
 
 include( CMakeDependentOption )
 
+
 ###
 # Add paths used throughout CMakeLists files
 ##
@@ -260,6 +261,62 @@ if( VIAME_BUILD_DEPENDENCIES )
 
   # Specifies internal arguments passed to all projects (CXX flag passdowns, etc)
   include( common_args )
+
+  # -----------
+
+  ###
+  # Prevent make from recompiling specific packages.
+  # For developer convinience only, do not use.
+  # Turning any of these off may make rebuild faster, but the build will fail
+  # (posibly silently) if any changes are made to those packages
+  ##
+  #set (VIAME_FORCEBUILD_KWIVER True)
+  #set (VIAME_FORCEBUILD_KWANT True)
+  #set (VIAME_FORCEBUILD_FLETCH True)
+  #set (VIAME_FORCEBUILD_BURNOUT True)
+  #set (VIAME_FORCEBUILD_SMQTK True)
+  #set (VIAME_FORCEBUILD_SCALLOP_TK True)
+  #set (VIAME_FORCEBUILD_VIAME True)
+  #set (VIAME_FORCEBUILD_VIVA True)
+  set (_viame_external_projects
+    burnout
+    darknet
+    fletch
+    kwant
+    kwiver
+    py-faster-rcnn
+    scallop_tk
+    smqtk
+    viame
+    vivia
+    )
+  foreach (target_name ${_viame_external_projects})
+    string(TOUPPER "${target_name}" target_name_upper)
+    set (_forcebuild_varname "VIAME_FORCEBUILD_${target_name_upper}")
+    set (_forcebuild_value ${${_forcebuild_varname}})
+
+    set(_give_forcebuild_option True)
+
+    if ("${target_name}" STREQUAL "viame")
+      # always force build viame dont give any option
+      set (_give_forcebuild_option False)
+    elseif ("${target_name}" STREQUAL "fletch")
+      # fletch is always enabled
+      set (_give_forcebuild_option True)
+    elseif ("${target_name}" STREQUAL "darknet")
+      set (_give_forcebuild_option ${VIAME_ENABLE_YOLO})  # name alias
+    elseif ("${target_name}" STREQUAL "py-faster-rcnn")
+      set (_give_forcebuild_option ${VIAME_ENABLE_FASTER_RCNN})  # name alias
+    else()
+      set (_give_forcebuild_option ${VIAME_ENABLE_${target_name_upper}})
+    endif()
+
+    if (_give_forcebuild_option)
+      option(${_forcebuild_varname} "always force this build" True)
+      mark_as_advanced(${_forcebuild_varname})
+    endif()
+  endforeach()
+
 
   # Hard VIAME requirements
   include( add_project_fletch )

--- a/cmake/add_project_burnout.cmake
+++ b/cmake/add_project_burnout.cmake
@@ -39,14 +39,7 @@ ExternalProject_Add(burnout
   INSTALL_DIR ${VIAME_BUILD_INSTALL_PREFIX}
   )
 
-ExternalProject_Add_Step(burnout forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/burnout-stamp/burnout-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(burnout)
 
 set(VIAME_ARGS_burnout
   -Dburnout_DIR:PATH=${VIAME_BUILD_PREFIX}/src/burnout-build

--- a/cmake/add_project_darknet.cmake
+++ b/cmake/add_project_darknet.cmake
@@ -44,14 +44,7 @@ ExternalProject_Add(darknet
   INSTALL_DIR ${VIAME_BUILD_INSTALL_PREFIX}
   )
 
-ExternalProject_Add_Step(darknet forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/darknet-stamp/darknet-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(darknet)
 
 set(VIAME_ARGS_darknet
   -Ddarknet_DIR:PATH=${VIAME_BUILD_PREFIX}/src/darknet-build

--- a/cmake/add_project_fletch.cmake
+++ b/cmake/add_project_fletch.cmake
@@ -115,6 +115,7 @@ else()
 endif()
 
 ExternalProject_Add(fletch
+  DEPENDS
   PREFIX ${VIAME_BUILD_PREFIX}
   SOURCE_DIR ${VIAME_PACKAGES_DIR}/fletch
   CMAKE_GENERATOR ${gen}
@@ -168,14 +169,7 @@ ExternalProject_Add(fletch
     -P ${VIAME_SOURCE_DIR}/cmake/custom_fletch_install.cmake
   )
 
-ExternalProject_Add_Step(fletch forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/fletch-stamp/fletch-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(fletch)
 
 set( VIAME_ARGS_fletch
   -Dfletch_DIR:PATH=${VIAME_BUILD_PREFIX}/src/fletch-build

--- a/cmake/add_project_kwant.cmake
+++ b/cmake/add_project_kwant.cmake
@@ -22,14 +22,7 @@ ExternalProject_Add(kwant
   INSTALL_DIR ${VIAME_BUILD_INSTALL_PREFIX}
   )
 
-ExternalProject_Add_Step(kwant forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/kwant-stamp/kwant-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(kwant)
 
 set(VIAME_ARGS_kwant
   -Dkwant_DIR:PATH=${VIAME_BUILD_PREFIX}/src/kwant-build

--- a/cmake/add_project_kwiver.cmake
+++ b/cmake/add_project_kwiver.cmake
@@ -85,14 +85,7 @@ ExternalProject_Add(kwiver
   INSTALL_DIR ${VIAME_BUILD_INSTALL_PREFIX}
   )
 
-ExternalProject_Add_Step(kwiver forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/kwiver-stamp/kwiver-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(kwiver)
 
 set(VIAME_ARGS_kwiver
   -Dkwiver_DIR:PATH=${VIAME_BUILD_PREFIX}/src/kwiver-build

--- a/cmake/add_project_scallop_tk.cmake
+++ b/cmake/add_project_scallop_tk.cmake
@@ -36,6 +36,7 @@ else()
   set( ScallopTK_CXXFLAGS_OVERRIDE )
 endif()
 
+if(VIAME_FORCEBUILD_SCALLOP_TK)
 ExternalProject_Add(scallop_tk
   DEPENDS fletch
   PREFIX ${VIAME_BUILD_PREFIX}
@@ -55,15 +56,9 @@ ExternalProject_Add(scallop_tk
     -DMODEL_INSTALL_DIR:PATH=examples/detector_pipelines/models/scallop_tk
   INSTALL_DIR ${VIAME_BUILD_INSTALL_PREFIX}
   )
+endif()
 
-ExternalProject_Add_Step(scallop_tk forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/scallop_tk-stamp/scallop_tk-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(scallop_tk)
 
 set(VIAME_ARGS_scallop_tk
   -DScallopTK_DIR:PATH=${VIAME_BUILD_PREFIX}/src/scallop_tk-build

--- a/cmake/add_project_smqtk.cmake
+++ b/cmake/add_project_smqtk.cmake
@@ -56,14 +56,7 @@ ExternalProject_Add_Step(smqtk installpy
   DEPENDEES build
   )
 
-ExternalProject_Add_Step(smqtk forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/smqtk-stamp/smqtk-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(smqtk)
 
 set(VIAME_ARGS_smqtk
   -Dsmqtk_DIR:PATH=${VIAME_BUILD_PREFIX}/src/smqtk-build

--- a/cmake/add_project_viame.cmake
+++ b/cmake/add_project_viame.cmake
@@ -45,11 +45,4 @@ ExternalProject_Add(viame
   INSTALL_DIR ${VIAME_BUILD_INSTALL_PREFIX}
   )
 
-ExternalProject_Add_Step(viame forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/viame-stamp/viame-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(viame FORCE)

--- a/cmake/add_project_vivia.cmake
+++ b/cmake/add_project_vivia.cmake
@@ -61,14 +61,7 @@ ExternalProject_Add(vivia
   INSTALL_DIR ${VIAME_BUILD_INSTALL_PREFIX}
   )
 
-ExternalProject_Add_Step(vivia forcebuild
-  COMMAND ${CMAKE_COMMAND}
-    -E remove ${VIAME_BUILD_PREFIX}/src/vivia-stamp/vivia-build
-  COMMENT "Removing build stamp file for build update (forcebuild)."
-  DEPENDEES configure
-  DEPENDERS build
-  ALWAYS 1
-  )
+VIAME_ExternalProject_Add_Step_Forcebuild(vivia)
 
 set(VIAME_ARGS_vivia
   -Dvivia_DIR:PATH=${VIAME_BUILD_PREFIX}/src/vivia-build

--- a/cmake/common_macros.cmake
+++ b/cmake/common_macros.cmake
@@ -58,3 +58,31 @@ function( RemoveDir _inDir )
 endfunction()
 
 
+###
+# Adds a standard VIAME forcebuild custom step to an external project
+###
+function( VIAME_ExternalProject_Add_Step_Forcebuild target_name )
+  cmake_parse_arguments(MY "FORCE" "" "" "${ARGN}")
+
+  string(TOUPPER "${target_name}" target_name_upper)
+  set (_forcebuild_varname "VIAME_FORCEBUILD_${target_name_upper}")
+  set (_forcebuild_value ${${_forcebuild_varname}})
+
+  if (NOT "${MY_FORCE}")
+    if ("${_forcebuild_value}" STREQUAL "")
+      message(WARNING "${_forcebuild_varname} is not set")
+      set(_forcebuild_value True)
+    endif()
+  endif()
+
+  if(MY_FORCE OR _forcebuild_value)
+    ExternalProject_Add_Step(${target_name} forcebuild
+      COMMAND ${CMAKE_COMMAND}
+        -E remove ${VIAME_BUILD_PREFIX}/src/${target_name}-stamp/${target_name}-build
+      COMMENT "Removing ${target_name} build stamp file for build update (forcebuild)."
+      DEPENDEES configure
+      DEPENDERS build
+      ALWAYS 1
+      )
+  endif()
+endfunction()


### PR DESCRIPTION
I was trying to build with all dependencies and I ran into an issue with smqtk, and it was a nightmare to try and fix the issue having to wait for VTK and all the other fletch projects to build before I could check if my smqtk fix worked. 

I recalled a conversation with @mattdawkins about disabling forced builds, and I found a way to do it. It is pretty hacky, but its simple enough where I think its fine as a stop-gap measure / developer-trick. 

All the `ExternalProject_Add_Step(<target> forcebuild...`  commands were basically the same, so I abstracted them all into a separate function. In this function I allowed a global variable called `VIAME_FORCEBUILD_<target>` to control whether or not they actually were force-built. 

I populate these variables as options in the main CMakeLists depending on which projects are enabled. Thus the user just flips one of these variables to false, and it wont automatically remove its build stamp anymore. 

Because it seems kind of dangerous / hacky to do this, these options are marked as advanced. 
I took care to ensure that any package without one of these variables defined would still be force-built, and I ensured that the viame project is never force built (nor is it even given the option).
