### PR TITLE
Fix linking to KWIVER by using correct targets

### DIFF
--- a/examples/external_plugin_creation/cxx/CMakeLists.txt
+++ b/examples/external_plugin_creation/cxx/CMakeLists.txt
@@ -48,12 +48,12 @@ add_library( ${PLUGIN_NAME}
   )
 
 target_link_libraries( ${PLUGIN_NAME}
-  PUBLIC               vital
-                       vital_algo
-                       vital_config
-                       vital_exceptions
-                       vital_logger
-                       kwiver_algo_ocv
+  PUBLIC               kwiver::vital
+                       kwiver::vital_algo
+                       kwiver::vital_config
+                       kwiver::vital_exceptions
+                       kwiver::vital_logger
+                       kwiver::kwiver_algo_ocv
   )
 
 set_target_properties( ${PLUGIN_NAME}

--- a/examples/using_detectors_in_cxx_code/CMakeLists.txt
+++ b/examples/using_detectors_in_cxx_code/CMakeLists.txt
@@ -26,13 +26,13 @@ if( VIAME_ENABLE_OPENCV )
   add_executable( detector1       detector1.cxx )
 
   target_link_libraries( detector1
-    PRIVATE    vital
-               vital_algo
-               vital_config
-               vital_logger
-               vital_util
-               kwiver_algo_core
-               kwiver_algo_ocv
+    PRIVATE    kwiver::vital
+               kwiver::vital_algo
+               kwiver::vital_config
+               kwiver::vital_logger
+               kwiver::vital_util
+               kwiver::kwiver_algo_core
+               kwiver::kwiver_algo_ocv
                ${OpenCV_LIBS}
     )
 
@@ -42,14 +42,14 @@ if( VIAME_ENABLE_OPENCV )
   add_executable( detector3       detector3.cxx )
 
   target_link_libraries( detector3
-    PRIVATE    vital
-               vital_algo
-               vital_config
-               vital_logger
-               vital_util
-               vital_vpm
-               kwiver_algo_core
-               kwiver_algo_ocv
+    PRIVATE    kwiver::vital
+               kwiver::vital_algo
+               kwiver::vital_config
+               kwiver::vital_logger
+               kwiver::vital_util
+               kwiver::vital_vpm
+               kwiver::kwiver_algo_core
+               kwiver::kwiver_algo_ocv
                ${OpenCV_LIBS}
     )
 

--- a/plugins/core/CMakeLists.txt
+++ b/plugins/core/CMakeLists.txt
@@ -36,13 +36,13 @@ kwiver_add_library( viame_core
   )
 
 target_link_libraries( viame_core
-  PUBLIC               vital
-                       vital_algo
-                       vital_config
-                       vital_exceptions
-                       vital_logger
-                       vital_util
-                       kwiversys
+  PUBLIC               kwiver::vital
+                       kwiver::vital_algo
+                       kwiver::vital_config
+                       kwiver::vital_exceptions
+                       kwiver::vital_logger
+                       kwiver::vital_util
+                       kwiver::kwiversys
   )
 
 set_target_properties( viame_core PROPERTIES
@@ -54,7 +54,7 @@ algorithms_create_plugin( viame_core
   )
   
 target_link_libraries( viame_core_plugin
-  PUBLIC               vital_vpm
+  PUBLIC               kwiver::vital_vpm
   )
 
 kwiver_add_executable( viame_train_detector
@@ -71,14 +71,14 @@ include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
 link_directories( ${Boost_LIBRARY_DIRS} )
 
 target_link_libraries( viame_train_detector
-  PRIVATE      vital
-               vital_vpm
-               vital_config
-               vital_exceptions
-               vital_logger
-               vital_algo
-               vital_util
-               kwiversys
+  PRIVATE      kwiver::vital
+               kwiver::vital_vpm
+               kwiver::vital_config
+               kwiver::vital_exceptions
+               kwiver::vital_logger
+               kwiver::vital_algo
+               kwiver::vital_util
+               kwiver::kwiversys
                kwiver::sprokit_pipeline
                kwiver::kwiver_adapter
                ${Boost_SYSTEM_LIBRARY}
@@ -103,10 +103,16 @@ kwiver_add_plugin( viame_processes_core
   SUBDIR           ${viame_plugin_process_subdir}
   SOURCES          ${process_sources}
                    ${private_headers}
-  PRIVATE          sprokit_pipeline
-                   kwiver_algo_core kwiversys kwiver_adapter
-                   vital vital_vpm vital_logger vital_config
-                   vital_util vital_exceptions
+  PRIVATE          kwiver::sprokit_pipeline
+                   kwiver::kwiver_algo_core
+                   kwiver::kwiversys
+                   kwiver::kwiver_adapter
+                   kwiver::vital
+                   kwiver::vital_vpm
+                   kwiver::vital_logger
+                   kwiver::vital_config
+                   kwiver::vital_util
+                   kwiver::vital_exceptions
                    ${Boost_SYSTEM_LIBRARY}
                    ${Boost_FILESYSTEM_LIBRARY}
  )

--- a/plugins/hello_world/CMakeLists.txt
+++ b/plugins/hello_world/CMakeLists.txt
@@ -27,12 +27,12 @@ kwiver_add_library( viame_hello_world
   )
 
 target_link_libraries( viame_hello_world
-  PUBLIC               vital
-                       vital_algo
-                       vital_config
-                       vital_exceptions
-                       vital_logger
-                       vital_util
+  PUBLIC               kwiver::vital
+                       kwiver::vital_algo
+                       kwiver::vital_config
+                       kwiver::vital_exceptions
+                       kwiver::vital_logger
+                       kwiver::vital_util
                        ${OpenCV_LIBRARIES}
   )
 
@@ -45,7 +45,7 @@ algorithms_create_plugin( viame_hello_world
   )
   
 target_link_libraries( viame_hello_world_plugin
-  PUBLIC               vital_vpm
+  PUBLIC               kwiver::vital_vpm
   )
 
 if( VIAME_ENABLE_PYTHON )

--- a/plugins/itk/CMakeLists.txt
+++ b/plugins/itk/CMakeLists.txt
@@ -40,9 +40,14 @@ kwiver_add_library( viame_itk
   )
 
 target_link_libraries( viame_itk
-  PUBLIC               vital vital_algo vital_config
-                       vital_exceptions vital_logger vital_util
-                       kwiversys ITKCommon
+  PUBLIC               kwiver::vital
+                       kwiver::vital_algo
+                       kwiver::vital_config
+                       kwiver::vital_exceptions
+                       kwiver::vital_logger
+                       kwiver::vital_util
+                       kwiver::kwiversys
+                       ITKCommon
   PRIVATE              ITKLabelMap ITKPath ITKOptimizersv4 ITKOptimizers
                        ITKStatistics ITKTransform ITKSpatialObjects
                        ITKEXPAT ITKMesh ITKQuadEdgeMesh ITKIOMeshFreeSurfer
@@ -67,7 +72,7 @@ algorithms_create_plugin( viame_itk
   )
 
 target_link_libraries( viame_itk_plugin
-  PUBLIC               vital_vpm
+  PUBLIC               kwiver::vital_vpm
   )
 
 # Add KWIVER plugin registration
@@ -102,11 +107,16 @@ if( VIAME_ENABLE_VXL AND VIAME_ENABLE_OPENCV )
     SUBDIR           ${viame_plugin_process_subdir}
     SOURCES          ${process_sources}
                      ${private_headers}
-    PRIVATE          sprokit_pipeline
+    PRIVATE          kwiver::sprokit_pipeline
                      viame_itk
-                     vital vital_vpm vital_logger vital_config
-                     kwiver_algo_core kwiver_algo_ocv
-                     kwiversys ${OpenCV_LIBS}
+                     kwiver::vital
+                     kwiver::vital_vpm
+                     kwiver::vital_logger
+                     kwiver::vital_config
+                     kwiver::kwiver_algo_core
+                     kwiver::kwiver_algo_ocv
+                     kwiver::kwiversys
+                     ${OpenCV_LIBS}
                      ITKIOTransformBase ITKTransformFactory
                      ITKIOTransformInsightLegacy
                      ITKIOHDF5 ITKIOTransformHDF5 ITKIOTransformMatlab

--- a/plugins/opencv/CMakeLists.txt
+++ b/plugins/opencv/CMakeLists.txt
@@ -45,14 +45,14 @@ endif()
 get_target_property( results viame_opencv COMPILE_DEFINITIONS )
 
 target_link_libraries( viame_opencv
-  PUBLIC               vital
-                       vital_algo
-                       vital_config
-                       vital_exceptions
-                       vital_logger
-                       vital_util
-                       kwiversys
-                       kwiver_algo_ocv
+  PUBLIC               kwiver::vital
+                       kwiver::vital_algo
+                       kwiver::vital_config
+                       kwiver::vital_exceptions
+                       kwiver::vital_logger
+                       kwiver::vital_util
+                       kwiver::kwiversys
+                       kwiver::kwiver_algo_ocv
                        ${OpenCV_LIBRARIES}
   )
 
@@ -65,7 +65,7 @@ algorithms_create_plugin( viame_opencv
   )
 
 target_link_libraries( viame_opencv_plugin
-  PUBLIC               vital_vpm
+  PUBLIC               kwiver::vital_vpm
   )
 
 if( VIAME_ENABLE_PYTHON )

--- a/plugins/scallop_tk/CMakeLists.txt
+++ b/plugins/scallop_tk/CMakeLists.txt
@@ -33,12 +33,12 @@ kwiver_add_library( viame_scallop_tk
   )
 
 target_link_libraries( viame_scallop_tk
-  PUBLIC               vital
-                       vital_algo
-                       vital_config
-                       vital_exceptions
-                       vital_logger
-                       kwiver_algo_ocv
+  PUBLIC               kwiver::vital
+                       kwiver::vital_algo
+                       kwiver::vital_config
+                       kwiver::vital_exceptions
+                       kwiver::vital_logger
+                       kwiver::kwiver_algo_ocv
                        opencv_core opencv_legacy
                        ScallopTK
   )
@@ -65,5 +65,5 @@ algorithms_create_plugin( viame_scallop_tk
   )
 
 target_link_libraries( viame_scallop_tk_plugin
-  PUBLIC               vital_vpm
+  PUBLIC               kwiver::vital_vpm
   )

--- a/plugins/templates/cxx/CMakeLists.txt
+++ b/plugins/templates/cxx/CMakeLists.txt
@@ -25,11 +25,11 @@ kwiver_add_library( viame_@template_lib@
   )
 
 target_link_libraries( viame_@template_lib@
-  PUBLIC               vital
-                       vital_algo
-                       vital_config
-                       vital_exceptions
-                       vital_logger
+  PUBLIC               kwiver::vital
+                       kwiver::vital_algo
+                       kwiver::vital_config
+                       kwiver::vital_exceptions
+                       kwiver::vital_logger
   )
 
 algorithms_create_plugin( viame_@template_lib@

--- a/plugins/uw_predictor/CMakeLists.txt
+++ b/plugins/uw_predictor/CMakeLists.txt
@@ -45,12 +45,12 @@ kwiver_add_library( viame_uw_predictor
   )
 
 target_link_libraries( viame_uw_predictor
-  PUBLIC               vital
-                       vital_algo
-                       vital_config
-                       vital_exceptions
-                       vital_logger
-                       kwiver_algo_ocv
+  PUBLIC               kwiver::vital
+                       kwiver::vital_algo
+                       kwiver::vital_config
+                       kwiver::vital_exceptions
+                       kwiver::vital_logger
+                       kwiver::kwiver_algo_ocv
                        opencv_ml
                        opencv_objdetect
   )
@@ -64,5 +64,5 @@ algorithms_create_plugin( viame_uw_predictor
   )
 
 target_link_libraries( viame_uw_predictor_plugin
-  PUBLIC               vital_vpm
+  PUBLIC               kwiver::vital_vpm
   )


### PR DESCRIPTION
Modify how we link to KWIVER to correctly use the namespaced target names. I have no idea why this is working for anyone else, but my KWIVER build has never provided non-namespaced targets.