### PR TITLE
Fixed bug in python plugin template

### DIFF
--- a/plugins/templates/python/template_detector.py
+++ b/plugins/templates/python/template_detector.py
@@ -73,10 +73,10 @@ class @template@_detector(KwiverProcess):
         in_img_c = self.grab_input_using_trait('image')
 
         # Get python image from conatiner (just for show)
-        in_img = in_img_c.get_image()
+        in_img = in_img_c.image()
 
         # Print out example_param to screen
-        print "Example parameter: " + str( self.example_param )
+        print('Example parameter: ' + str(self.example_param))
 
         # push dummy (empty) detections object to output port
         detections = DetectedObjectSet()


### PR DESCRIPTION
The plugin template for detector written in python doesn't work because it tries to access methods that are not present and also uses `print` statement which isn't present in Python 3. This PR is aimed to fix it. Please have a look.