### PR TITLE
Add converters for VIAME CSV <-> COCO

### DIFF
--- a/examples/detection_file_conversions/pipelines/coco_to_viame_csv.pipe
+++ b/examples/detection_file_conversions/pipelines/coco_to_viame_csv.pipe
@@ -1,0 +1,13 @@
+process read :: detected_object_input
+  file_name = input.coco.json
+  reader:type = DetectedObjectSetInputCoco
+
+process write :: detected_object_output
+  file_name = out.csv
+  writer:type = viame_csv
+
+connect from read.detected_object_set
+     	to write.detected_object_set
+
+connect from read.image_file_name
+     	to write.image_file_name

--- a/examples/detection_file_conversions/pipelines/viame_csv_to_coco.pipe
+++ b/examples/detection_file_conversions/pipelines/viame_csv_to_coco.pipe
@@ -1,0 +1,13 @@
+process read :: detected_object_input
+  file_name = input.csv
+  reader:type = viame_csv
+
+process write :: detected_object_output
+  file_name = out.coco.json
+  writer:type = DetectedObjectSetOutputCoco
+
+connect from read.detected_object_set
+     	to write.detected_object_set
+
+connect from read.image_file_name
+     	to write.image_file_name


### PR DESCRIPTION
This PR (currently) simply adds two pipeline files to convert VIAME CSV to and from the COCO format to the `detection_file_conversions` example.

Some possible points of attention:
- The other pipelines in this folder use an image list as input; these don't. (I'm not sure of the advantage of the former approach.)
- Related to the previous point, the CSV -> COCO converter requires #99 to work properly.
- I have a separate Python script, not included, to extract an image list from a COCO file, which is useful for creating an image list to accompany the CSV resulting from conversion. Do we also want this? If so, where? I have another script that runs both the conversion and the image list extraction, and again the question is where to put it.
- Is there a summary of the COCO format I could reference for this example's README? The format used does depart slightly from the one at http://cocodataset.org/#format-data, namely in the addition of a `"score"` attribute currently, but perhaps supporting more of the Kitware extensions later.