### PR TITLE
Update mosaic tool

### DIFF
--- a/examples/image_registration/create_mosaic.py
+++ b/examples/image_registration/create_mosaic.py
@@ -3,7 +3,7 @@ import glob
 import itertools as itt
 
 import numpy as np
-from scipy import ndimage
+import scipy.optimize
 from skimage import (
     io as skio,
     transform as sktr,
@@ -13,37 +13,78 @@ import tqdm
 def read_homog_file(path):
     """Read a homography output file into an Nx3x3 array.
     Coordinate order is Y, X, Z.
-    Only reads until the first break.
+    Also returns the reference frame for each frame.
 
     """
     with open(path) as f:
         # "start" will contain the starting index
         start = None
         result = []
+        refs = []
         for i, line in enumerate(f):
             *matrix, fromf, tof = line.split()
             if start is None:
-                assert int(fromf) == int(tof)
                 start = int(fromf)
             assert len(matrix) == 9
             assert int(fromf) == i + start
-            if int(tof) != start: break
             result.append(list(map(float, matrix)))
+            refs.append(int(tof))
     swap_xy = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
-    return swap_xy @ np.array(result).reshape((-1, 3, 3)) @ swap_xy
+    result = swap_xy @ np.array(result).reshape((-1, 3, 3)) @ swap_xy
+    return result, np.array(refs)
 
-def unhomogenize(coords):
-    """Signature (i+1, j) -> (i, j)"""
-    return coords[..., :-1, :] / coords[..., -1:, :]
+def transform_homog(homog, coords):
+    """Signature (n+1, n+1), n -> n"""
+    ones = np.ones(coords.shape[:-1] + (1,), dtype=coords.dtype)
+    coords = np.concatenate((coords, ones), axis=-1)[..., np.newaxis]
+    tcoords = homog @ coords
+    tcoords = np.squeeze(tcoords, -1)
+    return tcoords[..., :-1] / tcoords[..., -1:]
+
+def get_image_box(im_size):
+    y, x = im_size
+    y -= 1; x -= 1
+    return np.array([[0, 0], [y, 0], [0, x], [y, x]])
+
+def score_homog(homog, im_size):
+    """Signature (3, 3) -> () (fixing size as a pair)"""
+    box = get_image_box(im_size)
+    def get_dists(x):
+        """Signature (n, m) -> (n, n)"""
+        diffs = np.expand_dims(x, -3) - np.expand_dims(x, -2)
+        return (diffs ** 2).sum(-1) ** .5
+    tbox = transform_homog(np.expand_dims(homog, -3), box)
+    return ((get_dists(tbox) - get_dists(box)) ** 2).sum((-1, -2))
+
+def optimize_homog_fit(homogs, im_size):
+    """Return a homography that, when applied after the provided ndarray
+    of homographies, minimizes the distortion of images of the given
+    size
+
+    """
+    def embed(x):
+        result = np.empty((3, 3), dtype=x.dtype)
+        result.flat[:-1] = x
+        result[2, 2] = 1
+        return result
+    def score(x):
+        return score_homog(embed(x) @ homogs, im_size).sum()
+    result = scipy.optimize.minimize(
+        score, np.eye(3).flat[:-1], method='Nelder-Mead',
+    )
+    if result.success:
+        return embed(result.x)
+    else:
+        raise RuntimeError(
+            "Optimization failed with the message: " + result.message,
+        )
 
 def get_extreme_coordinates(homogs, im_size):
     """Return a pair of the UL and BR coordinates"""
-    y, x = im_size
-    y -= 1; x -= 1
-    box = np.array([[0, 0, 1], [y, 0, 1], [0, x, 1], [y, x, 1]]).T
-    transformed = unhomogenize(homogs @ box)
-    min_yx = np.floor(transformed.min((0, -1))).astype(int)
-    max_yx = np.ceil(transformed.max((0, -1))).astype(int)
+    box = get_image_box(im_size)
+    transformed = transform_homog(homogs[:, np.newaxis], box)
+    min_yx = np.floor(transformed.min((0, 1))).astype(int)
+    max_yx = np.ceil(transformed.max((0, 1))).astype(int)
     return tuple(min_yx), tuple(max_yx)
 
 def translator(offset):
@@ -65,10 +106,9 @@ def paste(dest, src, src_to_dest):
     assert src.ndim == 3 and src.shape[2] in (3, 4)
     if dest.dtype != np.uint8 or src.dtype != np.uint8:
         raise ValueError("Only 8-bit (per channel) images supported")
-    y, x = src.shape[:2]
-    bbox = np.array([[0, 0, 1], [y, 0, 1], [0, x, 1], [y, x, 1]]).T
-    trans_bbox = unhomogenize(src_to_dest @ bbox)
-    trans_ul, trans_br = trans_bbox.min(-1), trans_bbox.max(-1)
+    bbox = get_image_box(src.shape[:2])
+    trans_bbox = transform_homog(src_to_dest, bbox)
+    trans_ul, trans_br = trans_bbox.min(0), trans_bbox.max(0)
     # Round outward
     trans_ul = np.floor(trans_ul).astype(int)
     trans_br = np.ceil(trans_br).astype(int)
@@ -89,37 +129,73 @@ def paste(dest, src, src_to_dest):
     # Convert everything back to uint8 (warp converts to double)
     trans = (trans * 255).round().astype(np.uint8)
 
-    dest[tuple(m + ul for m, ul in zip(mask.nonzero(), trans_ul))] = trans[mask]
+    dest_slice = dest[tuple(slice(ul, br + 1) for ul, br in zip(trans_ul, trans_br))]
+    np.copyto(dest_slice, trans, where=mask[..., np.newaxis])
 
-def paste_many(homogs, ims):
-    """Given a sequence of homographies and an iterable of images, produce
-    a mosaic image
+def paste_many(homogs, ims, im0):
+    """Given a sequence of homographies, an iterable of images, and a
+    template image, produce a mosaic image
 
     """
-    ims = iter(ims)
-    im = next(ims)
-    im_size = im.shape[:2]
+    im_size = im0.shape[:2]
     ul, br = get_extreme_coordinates(homogs, im_size)
-    # XXX The extra + 1 is a hack
-    dest = np.zeros(tuple(np.array(br) - ul + 1 + 1) + (im.shape[2],), dtype=im.dtype)
-    for hom, im in zip(homogs, itt.chain([im], ims)):
+    dest = np.zeros(tuple(np.array(br) - ul + 1) + (im0.shape[2],), dtype=im0.dtype)
+    for hom, im in zip(homogs, ims):
         assert im.shape[:2] == im_size
         hom = translator(tuple(-x for x in ul)) @ hom
         paste(dest, im, hom)
     return dest
 
-def main(out_file, homog_file, image_glob, frames=None, start=None, stop=None, step=None):
-    image_files = sorted(glob.iglob(image_glob))[start:stop]
-    homogs = read_homog_file(homog_file)[start:stop]
-    length = min(len(image_files), len(homogs))
+def peek_iterable(it):
+    it = iter(it)
+    x = next(it)
+    return x, itt.chain([x], it)
+
+def main(out_file, homog_file, image_glob, **kwargs):
+    main_multi(out_file, [(homog_file, image_glob)], **kwargs)
+
+def main_multi(
+        out_file, homogs_and_globs, *, optimize_fit=None, zoom=None,
+        frames=None, start=None, stop=None, step=None, reverse=None,
+):
+    images_homogs_refs = ((
+        sorted(glob.iglob(image_glob)),
+        *read_homog_file(homog_file),
+    ) for homog_file, image_glob in homogs_and_globs)
+    images_homogs_refs = [tuple(
+        x[start:stop] for x in ihr
+    ) for ihr in images_homogs_refs]
+    length = min(len(x) for ihr in images_homogs_refs for x in ihr)
     if (frames is None) == (step is None):
         raise ValueError("Exactly one of frames and step must be specified")
     if frames is not None:
         frame_numbers = [(length - 1) * i // (frames - 1) for i in range(frames)]
     else:
         frame_numbers = range(0, length, step)
-    images = (skio.imread(image_files[i]) for i in tqdm.tqdm(frame_numbers))
-    skio.imsave(out_file, paste_many(homogs[frame_numbers], images))
+    if reverse:
+        frame_numbers = frame_numbers[::-1]
+    if len({
+            x for _, _, refs in images_homogs_refs
+            for x in np.unique(refs[frame_numbers])
+    }) > 1:
+        raise ValueError("Requested frames do not all have the same reference")
+    images = (skio.imread(image_files[i])
+              for i in tqdm.tqdm(frame_numbers)
+              for image_files, _, _ in images_homogs_refs)
+    im0, images = peek_iterable(images)
+    rel_homogs_4d = np.stack([
+        homogs[frame_numbers] for _, homogs, _ in images_homogs_refs
+    ], axis=1)
+    rel_homogs = rel_homogs_4d.reshape((-1, 3, 3))
+    if optimize_fit:
+        rel_homog_0 = rel_homogs_4d[-1 if reverse else 0, 0]
+        rel_homogs = np.linalg.inv(rel_homog_0) @ rel_homogs
+        fit_homog = optimize_homog_fit(rel_homogs, im0.shape[:2])
+        rel_homogs = fit_homog @ rel_homogs
+    if zoom is not None:
+        rel_homogs = np.diag([zoom, zoom, 1]) @ rel_homogs
+    skio.imsave(out_file, paste_many(rel_homogs, images, im0))
+    () = images  # Finally move the progress bar to 100%
 
 def create_parser():
     p = argparse.ArgumentParser()
@@ -130,6 +206,9 @@ def create_parser():
     p.add_argument('--start', type=int, metavar='N', help='Ignore first N frames')
     p.add_argument('--stop', type=int, metavar='N', help='Ignore frames after the Nth')
     p.add_argument('--step', type=int, metavar='N', help='Write every Nth frame')
+    p.add_argument('--reverse', action='store_true', help='Render images in reverse order')
+    p.add_argument('--optimize-fit', action='store_true', help='Apply an additional transformation to all images to minimize distortion')
+    p.add_argument('--zoom', type=float, metavar='Z', help='Scale the output image by a factor of Z')
     return p
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR has all the changes I've made to the `create_mosaic.py` tool. Summarizing the most important changes:
- Added support for drawing any range of images with a consistent reference frame, not just the first block.
- Added `--optimize-fit` flag that attempts to minimize distortion of the input images in the output.
- Added `--reverse` flag that draws earlier frames on top of later frames.
- Added `--zoom` option that scales the output image (most useful with values less than unity in order to reduce memory consumption).
- Added Python function `main_multi` that can draw multiple co-registered image sequences (not available at the command line).

And a couple bug fixes:
- Fixed rounding-related bug that caused crashes for some inputs (and removed associated workaround).
- The progress bar now will go to 100%, though only after the rendered mosaic is written to disk.