### PR TITLE
Add single-camera versions of the suppressor and tracker pipelines

### DIFF
--- a/configs/CMakeLists.txt
+++ b/configs/CMakeLists.txt
@@ -420,8 +420,10 @@ if( VIAME_DOWNLOAD_MODELS-SEA-LION )
   # XXX We also have a netharn dependency, though that's not declared
   # for the pipeline files in the sea lion model download
   set( CORE_PIPELINE_FILES ${CORE_PIPELINE_FILES}
+    pipelines/suppressor_sea_lion_1-cam.pipe
     pipelines/suppressor_sea_lion_2-cam.pipe
     pipelines/suppressor_sea_lion_3-cam.pipe
+    pipelines/tracker_sea_lion_1-cam.pipe
     pipelines/tracker_sea_lion_2-cam.pipe
     pipelines/tracker_sea_lion_3-cam.pipe )
 endif()
@@ -489,8 +491,10 @@ if( VIAME_ENABLE_SEAL_TK OR VIAME_DOWNLOAD_MODELS-ARCTIC-SEAL )
   if( VIAME_DOWNLOAD_MODELS-SEA-LION )
     # XXX See above regarding possible missing guards
     set( DUAL_EMBEDDED_FILES ${DUAL_EMBEDDED_FILES}
+      pipelines/embedded_dual_stream/suppressor_sea_lion_1-cam.pipe
       pipelines/embedded_dual_stream/suppressor_sea_lion_2-cam.pipe
       pipelines/embedded_dual_stream/suppressor_sea_lion_3-cam.pipe
+      pipelines/embedded_dual_stream/tracker_sea_lion_1-cam.pipe
       pipelines/embedded_dual_stream/tracker_sea_lion_2-cam.pipe
       pipelines/embedded_dual_stream/tracker_sea_lion_3-cam.pipe )
   endif()

--- a/configs/pipelines/embedded_dual_stream/suppressor_sea_lion_1-cam.pipe
+++ b/configs/pipelines/embedded_dual_stream/suppressor_sea_lion_1-cam.pipe
@@ -1,0 +1,129 @@
+config _scheduler
+  type = pythread_per_process
+
+process in_adapt :: input_adapter
+
+process stabilizer
+  :: many_image_stabilizer
+  n_input = 1
+
+  feature_detector:type = filtered
+  block feature_detector:filtered
+    detector:type = ocv_SURF
+    block detector:ocv_SURF
+      extended           = false
+      hessian_threshold  = 400
+      n_octave_layers    = 3
+      n_octaves          = 4
+      upright            = false
+    endblock
+
+    filter:type = nonmax
+    block filter:nonmax
+      num_features_target = 5000
+      num_features_range = 500
+    endblock
+  endblock
+
+  descriptor_extractor:type = ocv_SURF
+  block descriptor_extractor:ocv_SURF
+    extended           = false
+    hessian_threshold  = 400 # 5000
+    n_octave_layers    = 3
+    n_octaves          = 4
+    upright            = false
+  endblock
+
+  feature_matcher:type = ocv_flann_based
+
+  homography_estimator:type = vxl
+
+  ref_homography_computer:type = core
+  block ref_homography_computer:core
+    backproject_threshold = 4
+    allow_ref_frame_regression = false
+    min_matches_threshold = 50
+    estimator:type = vxl
+    forget_track_threshold = 5
+    inlier_scale = 10
+    min_track_length = 1
+    use_backproject_error = false
+  endblock
+
+connect from in_adapt.image
+        to stabilizer.image1
+
+process detector1
+  :: image_object_detector
+  :detector:type            netharn
+
+  block detector:netharn
+    relativepath deployed = ../models/sea_lion_multi_class.zip
+  endblock
+
+connect from in_adapt.image
+        to detector1.image
+
+process suppressor :: multicam_homog_det_suppressor
+  n_input = 1
+
+connect from stabilizer.homog1
+        to suppressor.homog1
+
+connect from detector1.detected_object_set
+        to suppressor.det_objs_1
+
+connect from in_adapt.image
+        to suppressor.image1
+
+
+# ==================================================================================
+# Commonly used default initializer when the user hasn't specified one.
+#
+# Current incumbent is just a straight-up threshold on detection scores.
+
+process track_initializer_1
+  :: initialize_object_tracks
+  :track_initializer:type                      threshold
+
+  block track_initializer:threshold:filter
+    :type                                      class_probablity_filter
+    :class_probablity_filter:threshold         0.001
+    :class_probablity_filter:keep_all_classes  true
+    :class_probablity_filter:keep_classes      ex1;ex2;these_are_unused
+  endblock
+
+connect from suppressor.det_objs_1
+        to track_initializer_1.detected_object_set
+connect from in_adapt.timestamp
+        to track_initializer_1.timestamp
+
+process write_homogs_1
+  :: kw_write_homography
+  output = homogs1.txt
+
+connect from stabilizer.homog1
+        to write_homogs_1.homography
+
+process write_tracks_1 :: write_object_track
+  file_name = tracks1.csv
+  frame_list_output = track_images_1.txt
+  writer:type = viame_csv
+
+connect from track_initializer_1.object_track_set
+        to write_tracks_1.object_track_set
+connect from in_adapt.timestamp
+        to write_tracks_1.timestamp
+connect from in_adapt.file_name
+        to write_tracks_1.image_file_name
+
+process out_adapt :: output_adapter
+
+connect from track_initializer_1.object_track_set
+        to out_adapt.object_track_set
+
+connect from in_adapt.timestamp
+        to out_adapt.timestamp
+
+connect from in_adapt.file_name
+        to out_adapt.file_name

--- a/configs/pipelines/embedded_dual_stream/tracker_sea_lion_1-cam.pipe
+++ b/configs/pipelines/embedded_dual_stream/tracker_sea_lion_1-cam.pipe
@@ -1,0 +1,107 @@
+config _scheduler
+  type = pythread_per_process
+
+process in_adapt :: input_adapter
+
+process stabilizer
+  :: many_image_stabilizer
+  n_input = 1
+
+  feature_detector:type = filtered
+  block feature_detector:filtered
+    detector:type = ocv_SURF
+    block detector:ocv_SURF
+      extended           = false
+      hessian_threshold  = 400
+      n_octave_layers    = 3
+      n_octaves          = 4
+      upright            = false
+    endblock
+
+    filter:type = nonmax
+    block filter:nonmax
+      num_features_target = 5000
+      num_features_range = 500
+    endblock
+  endblock
+
+  descriptor_extractor:type = ocv_SURF
+  block descriptor_extractor:ocv_SURF
+    extended           = false
+    hessian_threshold  = 400 # 5000
+    n_octave_layers    = 3
+    n_octaves          = 4
+    upright            = false
+  endblock
+
+  feature_matcher:type = ocv_flann_based
+
+  homography_estimator:type = vxl
+
+  ref_homography_computer:type = core
+  block ref_homography_computer:core
+    backproject_threshold = 4
+    allow_ref_frame_regression = false
+    min_matches_threshold = 50
+    estimator:type = vxl
+    forget_track_threshold = 5
+    inlier_scale = 10
+    min_track_length = 1
+    use_backproject_error = false
+  endblock
+
+connect from in_adapt.image
+        to stabilizer.image1
+
+process detector1
+  :: image_object_detector
+  :detector:type            netharn
+
+  block detector:netharn
+    relativepath deployed = ../models/sea_lion_multi_class.zip
+  endblock
+
+connect from in_adapt.image
+        to detector1.image
+
+process tracker :: multicam_homog_tracker
+  n_input = 1
+
+connect from stabilizer.homog1
+        to tracker.homog1
+
+connect from detector1.detected_object_set
+        to tracker.det_objs_1
+
+connect from in_adapt.timestamp
+        to tracker.timestamp
+
+process write_homogs_1
+  :: kw_write_homography
+  output = homogs1.txt
+
+connect from stabilizer.homog1
+        to write_homogs_1.homography
+
+process write_tracks_1 :: write_object_track
+  file_name = tracks1.csv
+  frame_list_output = track_images_1.txt
+  writer:type = viame_csv
+
+connect from tracker.obj_tracks_1
+        to write_tracks_1.object_track_set
+connect from in_adapt.timestamp
+        to write_tracks_1.timestamp
+connect from in_adapt.file_name
+        to write_tracks_1.image_file_name
+
+process out_adapt :: output_adapter
+
+connect from tracker.obj_tracks_1
+        to out_adapt.object_track_set
+
+connect from in_adapt.timestamp
+        to out_adapt.timestamp
+
+connect from in_adapt.file_name
+        to out_adapt.file_name

--- a/configs/pipelines/suppressor_sea_lion_1-cam.pipe
+++ b/configs/pipelines/suppressor_sea_lion_1-cam.pipe
@@ -1,0 +1,152 @@
+config _scheduler
+  type = pythread_per_process
+
+
+# ==================================================================================
+# Commonly used default input file source.
+#
+# By default, this is an image list reader, but this can be over-riden by changing
+# :video_reader:type to be vidl_ffmpeg for videos
+
+process input1
+  :: video_input
+  :video_filename                                       input_list_1.txt
+  :frame_time                                           1
+  :exit_on_invalid                                      false
+
+  :video_reader:type                                    image_list
+
+  block video_reader:vidl_ffmpeg
+    :time_source                                        start_at_0
+  endblock
+
+  block video_reader:image_list
+    :image_reader:type                                  vxl
+    :skip_bad_images                                    true
+
+    block image_reader:vxl
+      :force_byte                                       true
+    endblock
+
+    block image_reader:add_timestamp_from_filename
+      :image_reader:type                                vxl
+
+      block image_reader:vxl
+        :force_byte                                     true
+      endblock
+    endblock
+  endblock
+
+process stabilizer
+  :: many_image_stabilizer
+  n_input = 1
+
+  feature_detector:type = filtered
+  block feature_detector:filtered
+    detector:type = ocv_SURF
+    block detector:ocv_SURF
+      extended           = false
+      hessian_threshold  = 400
+      n_octave_layers    = 3
+      n_octaves          = 4
+      upright            = false
+    endblock
+
+    filter:type = nonmax
+    block filter:nonmax
+      num_features_target = 5000
+      num_features_range = 500
+    endblock
+  endblock
+
+  descriptor_extractor:type = ocv_SURF
+  block descriptor_extractor:ocv_SURF
+    extended           = false
+    hessian_threshold  = 400 # 5000
+    n_octave_layers    = 3
+    n_octaves          = 4
+    upright            = false
+  endblock
+
+  feature_matcher:type = ocv_flann_based
+
+  homography_estimator:type = vxl
+
+  ref_homography_computer:type = core
+  block ref_homography_computer:core
+    backproject_threshold = 4
+    allow_ref_frame_regression = false
+    min_matches_threshold = 50
+    estimator:type = vxl
+    forget_track_threshold = 5
+    inlier_scale = 10
+    min_track_length = 1
+    use_backproject_error = false
+  endblock
+
+connect from input1.image
+        to stabilizer.image1
+
+process detector1
+  :: image_object_detector
+  :detector:type            netharn
+
+  block detector:netharn
+    relativepath deployed = models/sea_lion_multi_class.zip
+  endblock
+
+connect from input1.image
+        to detector1.image
+
+process suppressor :: multicam_homog_det_suppressor
+  n_input = 1
+
+connect from stabilizer.homog1
+        to suppressor.homog1
+
+connect from detector1.detected_object_set
+        to suppressor.det_objs_1
+
+connect from input1.image
+        to suppressor.image1
+
+
+# ==================================================================================
+# Commonly used default initializer when the user hasn't specified one.
+#
+# Current incumbent is just a straight-up threshold on detection scores.
+
+process track_initializer_1
+  :: initialize_object_tracks
+  :track_initializer:type                      threshold
+
+  block track_initializer:threshold:filter
+    :type                                      class_probablity_filter
+    :class_probablity_filter:threshold         0.001
+    :class_probablity_filter:keep_all_classes  true
+    :class_probablity_filter:keep_classes      ex1;ex2;these_are_unused
+  endblock
+
+connect from suppressor.det_objs_1
+        to track_initializer_1.detected_object_set
+connect from input1.timestamp
+        to track_initializer_1.timestamp
+
+process write_homogs_1
+  :: kw_write_homography
+  output = homogs1.txt
+
+connect from stabilizer.homog1
+        to write_homogs_1.homography
+
+process write_tracks_1 :: write_object_track
+  file_name = tracks1.csv
+  frame_list_output = track_images_1.txt
+  writer:type = viame_csv
+
+connect from track_initializer_1.object_track_set
+        to write_tracks_1.object_track_set
+connect from input1.timestamp
+        to write_tracks_1.timestamp
+connect from input1.file_name
+        to write_tracks_1.image_file_name

--- a/configs/pipelines/tracker_sea_lion_1-cam.pipe
+++ b/configs/pipelines/tracker_sea_lion_1-cam.pipe
@@ -1,0 +1,130 @@
+config _scheduler
+  type = pythread_per_process
+
+
+# ==================================================================================
+# Commonly used default input file source.
+#
+# By default, this is an image list reader, but this can be over-riden by changing
+# :video_reader:type to be vidl_ffmpeg for videos
+
+process input1
+  :: video_input
+  :video_filename                                       input_list_1.txt
+  :frame_time                                           1
+  :exit_on_invalid                                      false
+
+  :video_reader:type                                    image_list
+
+  block video_reader:vidl_ffmpeg
+    :time_source                                        start_at_0
+  endblock
+
+  block video_reader:image_list
+    :image_reader:type                                  vxl
+    :skip_bad_images                                    true
+
+    block image_reader:vxl
+      :force_byte                                       true
+    endblock
+
+    block image_reader:add_timestamp_from_filename
+      :image_reader:type                                vxl
+
+      block image_reader:vxl
+        :force_byte                                     true
+      endblock
+    endblock
+  endblock
+
+process stabilizer
+  :: many_image_stabilizer
+  n_input = 1
+
+  feature_detector:type = filtered
+  block feature_detector:filtered
+    detector:type = ocv_SURF
+    block detector:ocv_SURF
+      extended           = false
+      hessian_threshold  = 400
+      n_octave_layers    = 3
+      n_octaves          = 4
+      upright            = false
+    endblock
+
+    filter:type = nonmax
+    block filter:nonmax
+      num_features_target = 5000
+      num_features_range = 500
+    endblock
+  endblock
+
+  descriptor_extractor:type = ocv_SURF
+  block descriptor_extractor:ocv_SURF
+    extended           = false
+    hessian_threshold  = 400 # 5000
+    n_octave_layers    = 3
+    n_octaves          = 4
+    upright            = false
+  endblock
+
+  feature_matcher:type = ocv_flann_based
+
+  homography_estimator:type = vxl
+
+  ref_homography_computer:type = core
+  block ref_homography_computer:core
+    backproject_threshold = 4
+    allow_ref_frame_regression = false
+    min_matches_threshold = 50
+    estimator:type = vxl
+    forget_track_threshold = 5
+    inlier_scale = 10
+    min_track_length = 1
+    use_backproject_error = false
+  endblock
+
+connect from input1.image
+        to stabilizer.image1
+
+process detector1
+  :: image_object_detector
+  :detector:type            netharn
+
+  block detector:netharn
+    relativepath deployed = models/sea_lion_multi_class.zip
+  endblock
+
+connect from input1.image
+        to detector1.image
+
+process tracker :: multicam_homog_tracker
+  n_input = 1
+
+connect from stabilizer.homog1
+        to tracker.homog1
+
+connect from detector1.detected_object_set
+        to tracker.det_objs_1
+
+connect from input1.timestamp
+        to tracker.timestamp
+
+process write_homogs_1
+  :: kw_write_homography
+  output = homogs1.txt
+
+connect from stabilizer.homog1
+        to write_homogs_1.homography
+
+process write_tracks_1 :: write_object_track
+  file_name = tracks1.csv
+  frame_list_output = track_images_1.txt
+  writer:type = viame_csv
+
+connect from tracker.obj_tracks_1
+        to write_tracks_1.object_track_set
+connect from input1.timestamp
+        to write_tracks_1.timestamp
+connect from input1.file_name
+        to write_tracks_1.image_file_name

--- a/configs/pipelines/write_multicam_stab_and_track.py
+++ b/configs/pipelines/write_multicam_stab_and_track.py
@@ -247,7 +247,7 @@ def create_file(type_, ncams, *, embedded):
 def main():
     for type_ in ['tracker', 'suppressor']:
         for embedded in [False, True]:
-            for ncams in [2, 3]:
+            for ncams in range(1, 4):
                 emb = 'embedded_dual_stream' if embedded else ''
                 mst = f'{type_}_sea_lion_{ncams}-cam.pipe'
                 out = PIPELINE_DIR / emb / mst


### PR DESCRIPTION
As stated, this PR adds single-camera versions of the suppressor and tracker pipelines.

To-do:
- [X] Test them
  - I ran a short test sequence for each, which included some registration failures, and they appeared to work as expected.

Since these pipelines are programmatically generated (from `write_multicam_stab_and_track.py`), perhaps it might eventually make sense to make that part of the build process.