### PR TITLE
Convert detections to tracks and write

### DIFF
--- a/configs/pipelines/detector_local.pipe
+++ b/configs/pipelines/detector_local.pipe
@@ -26,10 +26,34 @@ process detector_writer
   :file_name                                   computed_detections.csv
   :writer:type                                 viame_csv
 
+process track_initializer
+  :: initialize_object_tracks
+  :track_initializer:type                      threshold
+
+  block track_initializer:threshold:filter
+   :type                                      class_probablity_filter
+   :class_probablity_filter:threshold         0.0
+   :class_probablity_filter:keep_all_classes  true
+  endblock
+
+process track_writer
+  :: write_object_track
+  :file_name                                   computed_tracks.csv
+  :writer:type                                 viame_csv
+  :writer:viame_csv:active_writing             false
+
 connect from downsampler.output_1
         to   detector_input.image
 connect from downsampler.output_2
         to   detector_writer.image_file_name
+connect from downsampler.timestamp
+        to   track_initializer.timestamp
+
+connect from classifier1.detected_object_set
+        to   track_initializer.detected_object_set
+
+connect from track_initializer.object_track_set
+        to   track_writer.object_track_set
 
 connect from detector_output.detected_object_set
         to   detector_writer.detected_object_set

--- a/configs/pipelines/detector_local.pipe
+++ b/configs/pipelines/detector_local.pipe
@@ -30,7 +30,7 @@ process track_initializer
    :class_probablity_filter:keep_all_classes  true
   endblock
 
-process track_writer
+process detector_writer
   :: write_object_track
   :file_name                                   computed_tracks.csv
   :writer:type                                 viame_csv
@@ -39,7 +39,7 @@ process track_writer
 connect from downsampler.output_1
         to   detector_input.image
 connect from downsampler.output_2
-        to   track_writer.image_file_name
+        to   detector_writer.image_file_name
 connect from downsampler.timestamp
         to   track_initializer.timestamp
 
@@ -47,6 +47,6 @@ connect from detector_output.detected_object_set
         to   track_initializer.detected_object_set
 
 connect from track_initializer.object_track_set
-        to   track_writer.object_track_set
+        to   detector_writer.object_track_set
 
 # -- end of file --

--- a/configs/pipelines/detector_local.pipe
+++ b/configs/pipelines/detector_local.pipe
@@ -25,16 +25,16 @@ process track_initializer
   :track_initializer:type                      threshold
 
   block track_initializer:threshold:filter
-   :type                                      class_probablity_filter
-   :class_probablity_filter:threshold         0.0
-   :class_probablity_filter:keep_all_classes  true
+   :type                                       class_probablity_filter
+   :class_probablity_filter:threshold          0.0
+   :class_probablity_filter:keep_all_classes   true
   endblock
 
 process detector_writer
   :: write_object_track
   :file_name                                   computed_tracks.csv
   :writer:type                                 viame_csv
-  :writer:viame_csv:active_writing             false
+  :writer:viame_csv:active_writing             true
 
 connect from downsampler.output_1
         to   detector_input.image
@@ -42,6 +42,8 @@ connect from downsampler.output_2
         to   detector_writer.image_file_name
 connect from downsampler.timestamp
         to   track_initializer.timestamp
+connect from downsampler.timestamp
+        to   detector_writer.timestamp
 
 connect from detector_output.detected_object_set
         to   track_initializer.detected_object_set

--- a/configs/pipelines/detector_local.pipe
+++ b/configs/pipelines/detector_local.pipe
@@ -19,13 +19,7 @@ include common_default_input_with_downsampler.pipe
 
 include category_models/detector.pipe
 
-process detector_writer
-  :: detected_object_output
-
-  # Type of file to output
-  :file_name                                   computed_detections.csv
-  :writer:type                                 viame_csv
-
+# Create one-length tracks from detections for more informative saving
 process track_initializer
   :: initialize_object_tracks
   :track_initializer:type                      threshold
@@ -45,17 +39,14 @@ process track_writer
 connect from downsampler.output_1
         to   detector_input.image
 connect from downsampler.output_2
-        to   detector_writer.image_file_name
+        to   track_writer.image_file_name
 connect from downsampler.timestamp
         to   track_initializer.timestamp
 
-connect from classifier1.detected_object_set
+connect from detector_output.detected_object_set
         to   track_initializer.detected_object_set
 
 connect from track_initializer.object_track_set
         to   track_writer.object_track_set
-
-connect from detector_output.detected_object_set
-        to   detector_writer.detected_object_set
 
 # -- end of file --

--- a/configs/pipelines/full_frame_classifier_local.pipe
+++ b/configs/pipelines/full_frame_classifier_local.pipe
@@ -30,7 +30,7 @@ process track_initializer
   :class_probablity_filter:keep_all_classes    true
   endblock
 
-process track_writer
+process detector_writer
   :: write_object_track
   :file_name                                   computed_tracks.csv
   :writer:type                                 viame_csv
@@ -39,7 +39,7 @@ process track_writer
 connect from downsampler.output_1
         to   detector_input.image
 connect from downsampler.output_2
-        to   track_writer.image_file_name
+        to   detector_writer.image_file_name
 connect from downsampler.timestamp
         to   track_initializer.timestamp
 
@@ -47,6 +47,6 @@ connect from detector_output.detected_object_set
         to   track_initializer.detected_object_set
 
 connect from track_initializer.object_track_set
-        to   track_writer.object_track_set
+        to   detector_writer.object_track_set
 
 # -- end of file --

--- a/configs/pipelines/full_frame_classifier_local.pipe
+++ b/configs/pipelines/full_frame_classifier_local.pipe
@@ -19,19 +19,34 @@ include common_default_input_with_downsampler.pipe
 
 include category_models/detector.pipe
 
-process detector_writer
-  :: detected_object_output
+# Create one-length tracks from detections for more informative saving
+process track_initializer
+  :: initialize_object_tracks
+  :track_initializer:type                      threshold
 
-  # Type of file to output
-  :file_name                                   computed_detections.csv
+  block track_initializer:threshold:filter
+  :type                                        class_probablity_filter
+  :class_probablity_filter:threshold           0.0
+  :class_probablity_filter:keep_all_classes    true
+  endblock
+
+process track_writer
+  :: write_object_track
+  :file_name                                   computed_tracks.csv
   :writer:type                                 viame_csv
+  :writer:viame_csv:active_writing             false
 
 connect from downsampler.output_1
         to   detector_input.image
 connect from downsampler.output_2
-        to   detector_writer.image_file_name
+        to   track_writer.image_file_name
+connect from downsampler.timestamp
+        to   track_initializer.timestamp
 
 connect from detector_output.detected_object_set
-        to   detector_writer.detected_object_set
+        to   track_initializer.detected_object_set
+
+connect from track_initializer.object_track_set
+        to   track_writer.object_track_set
 
 # -- end of file --

--- a/configs/pipelines/full_frame_classifier_local.pipe
+++ b/configs/pipelines/full_frame_classifier_local.pipe
@@ -34,7 +34,7 @@ process detector_writer
   :: write_object_track
   :file_name                                   computed_tracks.csv
   :writer:type                                 viame_csv
-  :writer:viame_csv:active_writing             false
+  :writer:viame_csv:active_writing             true
 
 connect from downsampler.output_1
         to   detector_input.image
@@ -42,6 +42,8 @@ connect from downsampler.output_2
         to   detector_writer.image_file_name
 connect from downsampler.timestamp
         to   track_initializer.timestamp
+connect from downsampler.timestamp
+        to   detector_writer.timestamp
 
 connect from detector_output.detected_object_set
         to   track_initializer.detected_object_set

--- a/tools/process_video.py
+++ b/tools/process_video.py
@@ -270,8 +270,8 @@ def video_output_settings_list( options, basename ):
 
   return list(itertools.chain(
     fset( 'detector_writer:file_name=' + output_dir + div + basename + detection_ext ),
-    fset( 'track_writer:file_name=' + output_dir + div + basename + track_ext ),
-    fset( 'track_writer:stream_identifier=' + basename ),
+    fset( 'detection_writer:file_name=' + output_dir + div + basename + track_ext ),
+    fset( 'detection_writer:stream_identifier=' + basename ),
     fset( 'track_writer_db:writer:db:video_name=' + basename ),
     fset( 'track_writer_kw18:file_name=' + output_dir + div + basename + '.kw18' ),
     fset( 'descriptor_writer_db:writer:db:video_name=' + basename ),
@@ -487,9 +487,9 @@ def process_video_kwiver( input_name, options, is_image_list=False, base_ovrd=''
     command += groundtruth_reader_settings_list( options, gt_files, basename_no_ext, gpu, gt_type )
 
   if write_track_time:
-    command += fset( 'track_writer:writer:viame_csv:write_time_as_uid=true' )
+    command += fset( 'detection_writer:writer:viame_csv:write_time_as_uid=true' )
   else:
-    command += fset( 'track_writer:writer:viame_csv:stream_identifier=' + input_basename )
+    command += fset( 'detection_writer:writer:viame_csv:stream_identifier=' + input_basename )
 
   if len( options.input_detections ) > 0:
     command += fset( "detection_reader:file_name=" + options.input_detections )

--- a/tools/process_video.py
+++ b/tools/process_video.py
@@ -270,8 +270,9 @@ def video_output_settings_list( options, basename ):
 
   return list(itertools.chain(
     fset( 'detector_writer:file_name=' + output_dir + div + basename + detection_ext ),
-    fset( 'detection_writer:file_name=' + output_dir + div + basename + track_ext ),
-    fset( 'detection_writer:stream_identifier=' + basename ),
+    fset( 'detector_writer:stream_identifier=' + basename ),
+    fset( 'track_writer:file_name=' + output_dir + div + basename + track_ext ),
+    fset( 'track_writer:stream_identifier=' + basename ),
     fset( 'track_writer_db:writer:db:video_name=' + basename ),
     fset( 'track_writer_kw18:file_name=' + output_dir + div + basename + '.kw18' ),
     fset( 'descriptor_writer_db:writer:db:video_name=' + basename ),
@@ -487,9 +488,11 @@ def process_video_kwiver( input_name, options, is_image_list=False, base_ovrd=''
     command += groundtruth_reader_settings_list( options, gt_files, basename_no_ext, gpu, gt_type )
 
   if write_track_time:
-    command += fset( 'detection_writer:writer:viame_csv:write_time_as_uid=true' )
+    command += fset( 'track_writer:writer:viame_csv:write_time_as_uid=true' )
+    command += fset( 'detector_writer:writer:viame_csv:write_time_as_uid=true' )
   else:
-    command += fset( 'detection_writer:writer:viame_csv:stream_identifier=' + input_basename )
+    command += fset( 'track_writer:writer:viame_csv:stream_identifier=' + input_basename )
+    command += fset( 'detector_writer:writer:viame_csv:stream_identifier=' + input_basename )
 
   if len( options.input_detections ) > 0:
     command += fset( "detection_reader:file_name=" + options.input_detections )


### PR DESCRIPTION
This updates the `detector_local.pipe` to write out track files in addition to detections. This is because the detection writer doesn't currently write timestamps. 