### PR TITLE
Add pipes to add segmentations with OpenCV's watershed

### DIFF
--- a/configs/CMakeLists.txt
+++ b/configs/CMakeLists.txt
@@ -203,6 +203,7 @@ set( CORE_PIPELINE_FILES
   pipelines/common_image_stabilizer.pipe
   pipelines/common_stabilized_iou_tracker.pipe
   pipelines/database_apply_svm_models.pipe
+  pipelines/detector_add_segmentations.pipe
   pipelines/detector_extract_chips.pipe
   pipelines/detector_fish_without_motion.pipe
   pipelines/detector_generic_proposals.pipe

--- a/configs/pipelines/detector_add_segmentations.pipe
+++ b/configs/pipelines/detector_add_segmentations.pipe
@@ -1,0 +1,45 @@
+# Add automatically generated segmentations
+
+# ===================== GLOBAL PROPERTIES ========================
+# global pipeline config
+#
+config _pipeline:_edge
+       :capacity                                                 5
+
+# ====================== INPUT FRAME LIST ========================
+process input
+  :: video_input
+  :video_filename                                   input_list.txt
+  :frame_time                                              0.03333
+  :video_reader:type                                    image_list
+  :video_reader:image_list:image_reader:type                   vxl
+
+process detection_reader
+  :: detected_object_input
+  :file_name                                        detections.csv
+  :reader:type                                           viame_csv
+  :reader:viame_csv:poly_to_mask                              true
+
+process detection_refiner
+  :: refine_detections
+  :refiner:type                                      ocv_watershed
+  :refiner:ocv_watershed:seed_scale_factor                     0.2
+
+process detector_writer
+  :: detected_object_output
+  :file_name                                    converted_file.csv
+  :writer:type                                           viame_csv
+  :writer:viame_csv:mask_to_poly_tol                          0.05
+
+connect from input.image
+        to   detection_refiner.image
+
+connect from detection_reader.detected_object_set
+        to   detection_refiner.detected_object_set
+
+connect from input.file_name
+        to   detector_writer.image_file_name
+
+connect from detection_refiner.detected_object_set
+        to   detector_writer.detected_object_set
+

--- a/examples/detection_file_conversions/pipelines/viame_csv_add_segmentations.pipe
+++ b/examples/detection_file_conversions/pipelines/viame_csv_add_segmentations.pipe
@@ -1,0 +1,44 @@
+# Add automatically generated segmentations
+
+# ===================== GLOBAL PROPERTIES ========================
+# global pipeline config
+#
+config _pipeline:_edge
+       :capacity                                                 5
+
+# ====================== INPUT FRAME LIST ========================
+process image_reader
+  :: video_input
+  :video_filename                                   input_list.txt
+  :frame_time                                              0.03333
+  :video_reader:type                                    image_list
+  :video_reader:image_list:image_reader:type                   vxl
+
+process detection_reader
+  :: detected_object_input
+  :file_name                                        detections.csv
+  :reader:type                                           viame_csv
+
+process detection_refiner
+  :: refine_detections
+  :refiner:type                                      ocv_watershed
+  :refiner:ocv_watershed:seed_scale_factor                     0.2
+
+process detection_writer
+  :: detected_object_output
+  :file_name                                    converted_file.csv
+  :writer:type                                           viame_csv
+  :writer:viame_csv:mask_to_poly_tol                          0.05
+
+connect from image_reader.image
+        to   detection_refiner.image
+
+connect from detection_reader.detected_object_set
+        to   detection_refiner.detected_object_set
+
+connect from image_reader.file_name
+        to   detection_writer.image_file_name
+
+connect from detection_refiner.detected_object_set
+        to   detection_writer.detected_object_set
+


### PR DESCRIPTION
This depends on #125 and also needs Kitware/kwiver#1194 to be integrated. I've based this PR on #125's branch for clarity, but it shouldn't actually be merged into it.

This adds a file `viame_csv_add_segmentations.pipe` that uses the `ocv_watershed` implementation of `refine_detections` from Kitware/kwiver#1194. I've placed under the `detection_file_conversions` example, but there's probably a better place to put it.

It also adds `detector_add_segmentations.pipe` under `configs/pipelines`. This is substantially the same as the other one but is compatible with DIVE and is set to read in polygons from its input file.

`viame_csv_add_segmentations.pipe` could probably be removed. Perhaps we also want to add a GrabCut version (though GrabCut is significantly slower in my testing).