### PR TITLE
Fix DIVE docs link again

### DIFF
--- a/docs/manuals/section_links/documentation_overview.rst
+++ b/docs/manuals/section_links/documentation_overview.rst
@@ -12,6 +12,6 @@ There are 5 types of documentation within VIAME:
 
 .. _quick-start guide: https://data.kitware.com/api/v1/item/5fdaf1dd2fa25629b99843f8/download
 .. _overview presentation: https://www.viametoolkit.org/wp-content/uploads/2020/09/VIAME-AI-Workshop-Aug2020.pdf
-.. _VIAME-Web and DIVE Desktop docs: https://kitware.github.io/dive
+.. _VIAME Web and DIVE Desktop docs: https://kitware.github.io/dive
 .. _YouTube video channel: https://www.youtube.com/channel/UCpfxPoR5cNyQFLmqlrxyKJw
 .. _manual: https://viame.readthedocs.io/en/latest/


### PR DESCRIPTION
I think the link is messed up, but I really don't know how restructured text works