### PR TITLE
Check major and minor python versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,8 @@ if( VIAME_ENABLE_PYTHON )
     endif()
 
     if( NOT VIAME_DISABLE_PYTHON_CHECKS AND
-        ( NOT PYTHON_VERSION VERSION_EQUAL "3.6" OR
+        ( NOT PYTHON_VERSION_MAJOR EQUAL "3" OR
+          NOT PYTHON_VERSION_MINOR EQUAL "6" OR
           NOT PYTHON_VERSION_PATCH EQUAL "5" ) )
       message( FATAL_ERROR "Short-term, the only tested python distribution is "
         "Anaconda3 5.2.0, either install that version or set the cmake flag "


### PR DESCRIPTION
This code always failed for me. `PYTHON_VERSION` does not appear to be set until later in the code so I'm checking against the major and minor versions individually. While more verbose, this seems cleaner anyway. 