### PR TITLE
Improve mmdet detector

### DIFF
--- a/plugins/pytorch/mmdet_detector.py
+++ b/plugins/pytorch/mmdet_detector.py
@@ -32,6 +32,7 @@ class MMDetDetector(ImageObjectDetector):
         _Option('_gpu_index', 'gpu_index', "0", str),
         _Option('_display_detections', 'display_detections', False, strtobool),
         _Option('_template', 'template', "", str),
+        _Option('_auto_update_model', 'auto_update_model', True, strtobool),
     ]
 
     def __init__(self):
@@ -53,8 +54,9 @@ class MMDetDetector(ImageObjectDetector):
         for opt in self._options:
             setattr(self, opt.attr, opt.parse(cfg.get_value(opt.config)))
 
-        from viame.arrows.pytorch.mmdet_compatibility import check_config_compatibility
-        check_config_compatibility(self._net_config, self._weight_file, self._template)
+        if self._auto_update_model:
+            from viame.arrows.pytorch.mmdet_compatibility import check_config_compatibility
+            check_config_compatibility(self._net_config, self._weight_file, self._template)
 
         import matplotlib
         matplotlib.use('PS') # bypass multiple Qt load issues

--- a/plugins/pytorch/mmdet_detector.py
+++ b/plugins/pytorch/mmdet_detector.py
@@ -1,31 +1,6 @@
-# ckwg +29
-# Copyright 2019 by Kitware, Inc.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#  * Redistributions of source code must retain the above copyright notice,
-#  this list of conditions and the following disclaimer.
-#
-#  * Redistributions in binary form must reproduce the above copyright notice,
-#  this list of conditions and the following disclaimer in the documentation
-#  and/or other materials provided with the distribution.
-#
-#  * Neither name of Kitware, Inc. nor the names of any contributors may be used
-#  to endorse or promote products derived from this software without specific
-#  prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# This file is part of VIAME, and is distributed under the
+# OSI-approved BSD 3-Clause License. See top-level LICENSE.txt file or
+# https://github.com/VIAME/VIAME/blob/master/LICENSE.txt for details.
 
 from __future__ import print_function
 

--- a/plugins/pytorch/mmdet_detector.py
+++ b/plugins/pytorch/mmdet_detector.py
@@ -5,6 +5,7 @@
 from collections import namedtuple
 import sys
 
+import cv2
 from distutils.util import strtobool
 from kwiver.vital.algo import ImageObjectDetector
 from kwiver.vital.types import (
@@ -33,6 +34,7 @@ class MMDetDetector(ImageObjectDetector):
         _Option('_display_detections', 'display_detections', False, strtobool),
         _Option('_template', 'template', "", str),
         _Option('_auto_update_model', 'auto_update_model', True, strtobool),
+        _Option('_rgb_to_bgr', 'rgb_to_bgr', True, strtobool),
     ]
 
     def __init__(self):
@@ -81,6 +83,8 @@ class MMDetDetector(ImageObjectDetector):
 
     def detect(self, image_data):
         input_image = image_data.asarray().astype('uint8')
+        if self._rgb_to_bgr:
+            input_image = cv2.cvtColor(input_image, cv2.COLOR_RGB2BGR)
 
         from mmdet.apis import inference_detector
         detections = inference_detector(self._model, input_image)

--- a/plugins/pytorch/mmdet_detector.py
+++ b/plugins/pytorch/mmdet_detector.py
@@ -2,20 +2,15 @@
 # OSI-approved BSD 3-Clause License. See top-level LICENSE.txt file or
 # https://github.com/VIAME/VIAME/blob/master/LICENSE.txt for details.
 
-from __future__ import print_function
+import sys
 
+from distutils.util import strtobool
 from kwiver.vital.algo import ImageObjectDetector
-
 from kwiver.vital.types import (
     BoundingBoxD, DetectedObject, DetectedObjectSet, DetectedObjectType
 )
-
-from distutils.util import strtobool
-
-import numpy as np
-import sys
-
 import mmcv
+import numpy as np
 
 
 class MMDetDetector(ImageObjectDetector):


### PR DESCRIPTION
This PR contains assorted improvements to `plugins/pytorch/mmdet_detector.py`:
- Shortened copyright notice to a year-free form similar to what KWIVER uses
- Style improvements: sorted imports and removed spaces within brackets
- Converted config options to single-line specifications
- Added option `auto_update_model` (default true) that can be set to false to avoid calling `check_config_compatibility`, which AFAICT isn't expected to work with architectures other than the default
- Added option `rgb_to_bgr` (default true) that converts inputs to BGR, which is what the default architecture expects

The main changes are the two new options. `rgb_to_bgr`, together with its being enabled by default, fixes to what my understanding is a bug &ndash; as far as I can tell, the detector pipelines (at least `configs/pipelines/templates/detector_mmdet.pipe`) load and pass through images in RGB and `MMDetDetector` passes it through like that to the wrapped detector, even though the default configuration (or at least `configs/pipelines/templates/detector_mmdet.py`) expects BGR input.