### PR TITLE
Move Addon definitions to CSV file

### DIFF
--- a/cmake/download_viame_addons.csv
+++ b/cmake/download_viame_addons.csv
@@ -1,0 +1,8 @@
+https://data.kitware.com/api/v1/item/6011e3452fa25629b91ade60/download,habcam
+https://viame.kitware.com/api/v1/item/627b32b1994809b024f207a7/download,SEFSC
+https://viame.kitware.com/api/v1/item/627b3289ea630db5587b577d/download,PengHead
+https://viame.kitware.com/api/v1/item/627b326fea630db5587b577b/download,Motion
+https://viame.kitware.com/api/v1/item/627b326cc4da86e2cd3abb5b/download,EM Tuna
+https://viame.kitware.com/api/v1/item/627b3282c4da86e2cd3abb5d/download,MOUSS Deep 7
+https://viame.kitware.com/api/v1/item/615bc7aa7e5c13a5bb9af7a7/download,Aerial Penguin
+https://viame.kitware.com/api/v1/item/627b0b877b5df7aa226545ef/download,Sea Lion

--- a/cmake/download_viame_addons.csv
+++ b/cmake/download_viame_addons.csv
@@ -1,8 +1,8 @@
-https://data.kitware.com/api/v1/item/6011e3452fa25629b91ade60/download,habcam
-https://viame.kitware.com/api/v1/item/627b32b1994809b024f207a7/download,SEFSC
-https://viame.kitware.com/api/v1/item/627b3289ea630db5587b577d/download,PengHead
-https://viame.kitware.com/api/v1/item/627b326fea630db5587b577b/download,Motion
-https://viame.kitware.com/api/v1/item/627b326cc4da86e2cd3abb5b/download,EM Tuna
-https://viame.kitware.com/api/v1/item/627b3282c4da86e2cd3abb5d/download,MOUSS Deep 7
-https://viame.kitware.com/api/v1/item/615bc7aa7e5c13a5bb9af7a7/download,Aerial Penguin
-https://viame.kitware.com/api/v1/item/627b0b877b5df7aa226545ef/download,Sea Lion
+HabCam,https://viame.kitware.com/api/v1/item/627b145487bad2e19a4c4697/download,Detect scallops, flatfish, and roundfish
+SEFSC,https://viame.kitware.com/api/v1/item/627b32b1994809b024f207a7/download,200 species fish detector and trackers for Gulf of Mexico
+SWFSC-PengHead,https://viame.kitware.com/api/v1/item/627b3289ea630db5587b577d/download,Penguin headcam classification
+Motion,https://viame.kitware.com/api/v1/item/627b326fea630db5587b577b/download,Generic moving object detectors
+EM Tuna,https://viame.kitware.com/api/v1/item/627b326cc4da86e2cd3abb5b/download,On-board deck camera for tuna box and head/tail detection
+MOUSS Deep 7,https://viame.kitware.com/api/v1/item/627b3282c4da86e2cd3abb5d/download,MOUSS deep7 fish detection in hawaii
+Aerial Penguin,https://viame.kitware.com/api/v1/item/615bc7aa7e5c13a5bb9af7a7/download,Aerial penguin detection from fixed wings/drones
+Sea Lion,https://viame.kitware.com/api/v1/item/629807c192adc2f0ecfa5b54/download,Sea lion aerial detection data

--- a/cmake/download_viame_addons.sh
+++ b/cmake/download_viame_addons.sh
@@ -8,7 +8,7 @@ export DOWNLOAD_LOCATION=/tmp/VIAME-Addons
 mkdir -p ${DOWNLOAD_LOCATION}
 
 # Download All Optional Packages
-while IFS=, read -r DOWNLOAD_URL ADDON_NAME
+while IFS=, read -r ADDON_NAME DOWNLOAD_URL DESCRIPTION
 do
   wget -O "${DOWNLOAD_LOCATION}/${ADDON_NAME}.zip" ${DOWNLOAD_URL}
   unzip -o "${DOWNLOAD_LOCATION}/${ADDON_NAME}.zip" -d ${VIAME_INSTALL}

--- a/cmake/download_viame_addons.sh
+++ b/cmake/download_viame_addons.sh
@@ -8,38 +8,11 @@ export DOWNLOAD_LOCATION=/tmp/VIAME-Addons
 mkdir -p ${DOWNLOAD_LOCATION}
 
 # Download All Optional Packages
-
-# Habcam -
-wget -O ${DOWNLOAD_LOCATION}/download1.zip https://viame.kitware.com/api/v1/item/627b145487bad2e19a4c4697/download
-unzip -o ${DOWNLOAD_LOCATION}/download1.zip -d ${VIAME_INSTALL}
-
-# SEFSC -
-wget -O ${DOWNLOAD_LOCATION}/download2.zip https://viame.kitware.com/api/v1/item/627b32b1994809b024f207a7/download
-unzip -o ${DOWNLOAD_LOCATION}/download2.zip -d ${VIAME_INSTALL}
-
-# PengHead -
-wget -O ${DOWNLOAD_LOCATION}/download3.zip https://viame.kitware.com/api/v1/item/627b3289ea630db5587b577d/download
-unzip -o ${DOWNLOAD_LOCATION}/download3.zip -d ${VIAME_INSTALL}
-
-# Motion -
-wget -O ${DOWNLOAD_LOCATION}/download4.zip https://viame.kitware.com/api/v1/item/627b326fea630db5587b577b/download
-unzip -o ${DOWNLOAD_LOCATION}/download4.zip -d ${VIAME_INSTALL}
-
-# EM Tuna -
-wget -O ${DOWNLOAD_LOCATION}/download5.zip https://viame.kitware.com/api/v1/item/627b326cc4da86e2cd3abb5b/download
-unzip -o ${DOWNLOAD_LOCATION}/download5.zip -d ${VIAME_INSTALL}
-
-# MOUSS Deep 7 -
-wget -O ${DOWNLOAD_LOCATION}/download6.zip https://viame.kitware.com/api/v1/item/627b3282c4da86e2cd3abb5d/download
-unzip -o ${DOWNLOAD_LOCATION}/download6.zip -d ${VIAME_INSTALL}
-
-# Aerial Penguin
-wget -O ${DOWNLOAD_LOCATION}/download7.zip https://viame.kitware.com/api/v1/item/615bc7aa7e5c13a5bb9af7a7/download
-unzip -o ${DOWNLOAD_LOCATION}/download7.zip -d ${VIAME_INSTALL}
-
-# Sea Lion
-wget -O ${DOWNLOAD_LOCATION}/download8.zip https://viame.kitware.com/api/v1/item/629807c192adc2f0ecfa5b54/download
-unzip -o ${DOWNLOAD_LOCATION}/download8.zip -d ${VIAME_INSTALL}
+while IFS=, read -r DOWNLOAD_URL ADDON_NAME
+do
+  wget -O "${DOWNLOAD_LOCATION}/${ADDON_NAME}.zip" ${DOWNLOAD_URL}
+  unzip -o "${DOWNLOAD_LOCATION}/${ADDON_NAME}.zip" -d ${VIAME_INSTALL}
+done < download_viame_addons.csv
 
 # Ensure Download Location is Removed
 rm -rf ${DOWNLOAD_LOCATION}


### PR DESCRIPTION
Several people have asked us how to keep addons in Web up to date.  Until now, we've had to manually enter addon URLs into the update function, but this isn't ideal.

This change will allow VIAME Web (and potentially desktop -- you could imagine a "download addons" button in desktop) to pull the addon manifest directly without requiring any input from the user.  It could also allow users in the future to choose what addons they want to install by name.

The point of this change is to make the addon manifest machine readable.

@mattdawkins will need to update the CMAKE script to make sure this new `download_viame_addons.csv` is included however it needs to be included.

I'd also like feedback from @BryonLewis to make sure this is the best way to accomplish what we need.