### PR TITLE
[fix] Fix stereo 3D coordinates attribute names to reflect DIVE changes

### DIFF
--- a/plugins/core/calibrate_cameras_from_tracks_process.cxx
+++ b/plugins/core/calibrate_cameras_from_tracks_process.cxx
@@ -160,8 +160,8 @@ calibrate_cameras_from_tracks_process::priv::split_object_track(const kv::object
       }
 
       // Only keep image and world points for which xyz values has been found in notes
-      if (attrs.count("x") && attrs.count("y") && attrs.count("z")) {
-        kv::vector_3d pt = kv::vector_3d(attrs["x"], attrs["y"], attrs["z"]);
+      if (attrs.count("stereo3d_x") && attrs.count("stereo3d_y") && attrs.count("stereo3d_z")) {
+        kv::vector_3d pt = kv::vector_3d(attrs["stereo3d_x"], attrs["stereo3d_y"], attrs["stereo3d_z"]);
         if (!landmarks.count(track->id())) {
           landmarks[track->id()] = kv::landmark_sptr(new kv::landmark_d(pt));
         }

--- a/plugins/core/detections_pairing_from_stereo.cxx
+++ b/plugins/core/detections_pairing_from_stereo.cxx
@@ -398,9 +398,9 @@ viame::core::Detections3DPositions viame::core::detections_pairing_from_stereo::
 
   // Add 3d estimations to state if score is valid
   if (position.score > 0) {
-    detection->add_note(":x=" + std::to_string(position.center3d.x));
-    detection->add_note(":y=" + std::to_string(position.center3d.y));
-    detection->add_note(":z=" + std::to_string(position.center3d.z));
+    detection->add_note(":stereo3d_x=" + std::to_string(position.center3d.x));
+    detection->add_note(":stereo3d_y=" + std::to_string(position.center3d.y));
+    detection->add_note(":stereo3d_z=" + std::to_string(position.center3d.z));
     detection->add_note(":score=" + std::to_string(position.score));
   }
 

--- a/plugins/opencv/ocv_target_detector.cxx
+++ b/plugins/opencv/ocv_target_detector.cxx
@@ -164,9 +164,9 @@ detect( kv::image_container_sptr image_data ) const
     
     // Add detected OCV target corners and world coordinates corners into notes
     kv::detected_object_sptr detected_object = std::make_shared< kv::detected_object >( bbox, 1.0, dot );
-    detected_object->add_note(":x=" + std::to_string( world_corners[i].x ));
-    detected_object->add_note(":y=" + std::to_string( world_corners[i].y ));
-    detected_object->add_note(":z=" + std::to_string( world_corners[i].z ));
+    detected_object->add_note(":stereo3d_x=" + std::to_string( world_corners[i].x ));
+    detected_object->add_note(":stereo3d_y=" + std::to_string( world_corners[i].y ));
+    detected_object->add_note(":stereo3d_z=" + std::to_string( world_corners[i].z ));
     detected_set->add( detected_object );
   }
   


### PR DESCRIPTION
* Update x, y, z attribute names to stereo3d_x, stereo3d_y and stereo3d_z. 

See #161 for discussions related to multicam and 3D detection storage information