### PR TITLE
fix: update deprecated use of kwimage.Boxes.to_tlbr

### DIFF
--- a/plugins/pytorch/netharn_detector.py
+++ b/plugins/pytorch/netharn_detector.py
@@ -272,7 +272,11 @@ def _kwimage_to_kwiver_detections(detections):
     if 'segmentations' in detections.data:
         segmentations = detections.data['segmentations']
 
-    boxes = detections.boxes.to_tlbr()
+    try:
+        boxes = detections.boxes.to_ltrb()
+    except Exception:
+        boxes = detections.boxes.to_tlbr()
+
     scores = detections.scores
     class_idxs = detections.class_idxs
 


### PR DESCRIPTION
Fixes an issue in the netharn detection pipeline with new versions of kwimage. Maintains backwards compatibility if older versions of kwimage are installed. 