### PR TITLE
Fix ignoring sam2 refined detections with negative bbox start

### DIFF
--- a/plugins/pytorch/sam2_refiner.py
+++ b/plugins/pytorch/sam2_refiner.py
@@ -222,6 +222,19 @@ class Sam2Refiner(RefineDetections):
             # Extract the new mask info relative to the vital box
             box = vital_box_to_kwiamge(vital_det.bounding_box)
             sl = box.quantize().to_slice()
+
+            # Shift binmask and slice if negative slice start value
+            if sl[0].start < 0:
+                shift = -sl[0].start
+                binmask = np.roll(binmask, shift, axis=0)
+                binmask[:shift] = np.zeros((binmask[:shift].shape))
+                sl = (slice(0, sl[0].stop - sl[0].start), sl[1])
+            if sl[1].start < 0:
+                shift = -sl[1].start
+                binmask = np.roll(binmask, shift, axis=1)
+                binmask[:,:shift] = np.zeros((binmask[:,:shift].shape))
+                sl = (sl[0], slice(0, sl[1].stop - sl[1].start))
+
             relative_submask: np.ndarray = binmask[sl]
             submask_dims: tuple = relative_submask.shape[0:2]
 


### PR DESCRIPTION
Just fixed a bug in which box with a negative start value are ignored from the refiner.
(The bug only happens when `start value < 0` but not when `end value > imagesize`)

The bug is not coming from SAM2 which support bounding box with values outside the image.
It is produced due to negative slice indices when subscripting the binary mask.

When slice indices are greater than binmask size, slicing is caped by binmask shape.
However, when slice indices are negative, it is converted as `binmask.shape - slice_value`.
In this case, we have `slice start > slice end` and the resulting selected mask is empty.

One possible solution could be to clamp detection bounding box, but for some reasons, users could want to keep them unchanged.

So my solution is to shift the mask by creating a padding in the negative area to keep bounding box coordinates unchanged.

Before running SAM2 refiner:
![only-detections](https://github.com/user-attachments/assets/ad98b615-0a32-406c-98ba-ad53a427bfae)

After running SAM2 refiner (currently):
![bug](https://github.com/user-attachments/assets/d380d7f1-d11e-412a-b3c0-98164f83ef00)

After running Sam2 refiner (with patch):
![solved](https://github.com/user-attachments/assets/45195d0e-2e92-4a8a-87dc-adddcac295bb)
