### PR TITLE
fix: replace bare except with except Exception in score_results.py

### DIFF
--- a/tools/score_results.py
+++ b/tools/score_results.py
@@ -91,7 +91,7 @@ def float_to_str_safe( value ):
   except ValueError:
     print( "ValueError converting float value: " + value )
     return str( value )
-  except:
+  except Exception:
     print( "Unknown exception converting float value: " + value )
     return str( value )
 
@@ -102,7 +102,7 @@ def load_hierarchy( filename ):
     hierarchy = CategoryHierarchy()
     try:
       hierarchy.load_from_file( filename )
-    except:
+    except Exception:
       print_and_exit( "Unable to parse classes file: " + filename )
     return True
   else:
@@ -126,7 +126,7 @@ def safe_val( input_str ):
     if math.isnan( out ):
       return min_conf
     return out
-  except:
+  except Exception:
     return min_conf
 
 def neg_safe_val( input_str ):


### PR DESCRIPTION
## Summary

Replace 3 bare `except:` clauses with `except Exception:` in `tools/score_results.py`. Bare excepts catch all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which should generally propagate.

**Change:**
```python
# Before (lines 94, 105, 129)
except:
    ...

# After
except Exception:
    ...
```

## Testing
No behavior change for normal exceptions — style/correctness fix per PEP 8.