### PR TITLE
fix: Changed extract_chips pipeline default write path

### DIFF
--- a/configs/pipelines/filter_extract_chips.pipe
+++ b/configs/pipelines/filter_extract_chips.pipe
@@ -27,7 +27,7 @@ connect from downsampler.output_2
 process chipper
   :: refine_detections
   :refiner:type                                ocv_write
-  :refiner:ocv_write:pattern                   output/%s-%s+%d_%d_%dx%d.png
+  :refiner:ocv_write:pattern                   %s-%s+%d_%d_%dx%d.png
 
 connect from detection_reader.detected_object_set
         to   chipper.detected_object_set

--- a/configs/pipelines/filter_extract_chips.pipe
+++ b/configs/pipelines/filter_extract_chips.pipe
@@ -29,7 +29,7 @@ connect from downsampler.output_2
 process chipper
   :: refine_detections
   :refiner:type                                ocv_write
-  :refiner:ocv_write:pattern                   output/%s-%s+%d_%d_%dx%d.png  # DIVE_PARAM["Filename template", string]
+  :refiner:ocv_write:pattern                   %s-%s+%d_%d_%dx%d.png  # DIVE_PARAM["Filename template", string]
 
 connect from detection_reader.detected_object_set
         to   chipper.detected_object_set


### PR DESCRIPTION
See issue #231 

Changed default write path of the pipeline to remove the `output/` prefix, otherwise images are not written by opencv.  