### PR TITLE
fix: Removed 'timestamp' from detector writer of tracks_only_adjust_csv

### DIFF
--- a/configs/pipelines/filter_tracks_only_adjust_csv.pipe
+++ b/configs/pipelines/filter_tracks_only_adjust_csv.pipe
@@ -97,8 +97,6 @@ process detector_writer
 
 connect from downsampler2.output_3
         to   detector_writer.detected_object_set
-connect from downsampler2.timestamp
-        to   detector_writer.timestamp
 connect from image_writer.image_file_name
         to   detector_writer.image_file_name
 


### PR DESCRIPTION
Closing #235 

The detector_writer process doesn't have any `timestamp` port, but a connection to it is declared in `filter_tracks_only_adjust_csv.pipe` file, leading to a crash.