### PR TITLE
Kwcoco detector kit main

### DIFF
--- a/cmake/add_project_python_deps.cmake
+++ b/cmake/add_project_python_deps.cmake
@@ -116,7 +116,7 @@ if( VIAME_ENABLE_PYTORCH-MMDET OR VIAME_ENABLE_PYTORCH-NETHARN )
 endif()
 
 if( VIAME_ENABLE_PYTORCH-NETHARN )
-  list( APPEND VIAME_PYTHON_BASIC_DEPS "scriptconfig" "parse" )
+  list( APPEND VIAME_PYTHON_BASIC_DEPS "scriptconfig" "kwconf" "parse" )
   list( APPEND VIAME_PYTHON_BASIC_DEPS "kwarray" "kwimage" "kwplot" )
   list( APPEND VIAME_PYTHON_BASIC_DEPS "astunparse" "pygtrie" "pyflakes" )
 endif()

--- a/configs/pipelines/templates/detector_kwcoco_detector_kit.pipe
+++ b/configs/pipelines/templates/detector_kwcoco_detector_kit.pipe
@@ -1,0 +1,129 @@
+# =============================================================================
+# Title: kwcoco_detector_kit ONNX Detector
+#
+# Description: Runs a DEIMv2/kwcoco_detector_kit ONNX package on input imagery
+# from disk.  No PyTorch required at inference time — only onnxruntime.
+#
+# Required edit: replace [-PACKAGE-] with the path to the exported ONNX
+# package directory (or .zip archive) produced by:
+#
+#   python -m kwcoco_detector_kit export-onnx <workdir>
+#
+# Optional edits: score_thresh, device (cpu / cuda / cuda:0).
+# nms_thresh is accepted but advisory — NMS is baked into the ONNX graph.
+# =============================================================================
+
+config _pipeline:_edge
+  :capacity                                    5
+
+config _scheduler
+  :type                                        pythread_per_process
+
+# =============================================================================
+
+process input
+  :: video_input
+  :video_filename                              input_list.txt
+  :frame_time                                  1
+  :exit_on_invalid                             false
+
+  :video_reader:type                           image_list
+
+  block video_reader:vidl_ffmpeg
+    :time_source                               start_at_0
+  endblock
+
+  block video_reader:image_list
+    :image_reader:type                         vxl
+    :skip_bad_images                           true
+
+    block image_reader:vxl
+      :force_byte                              true
+    endblock
+
+    block image_reader:add_timestamp_from_filename
+      :image_reader:type                       vxl
+
+      block image_reader:vxl
+        :force_byte                            true
+      endblock
+    endblock
+  endblock
+
+process downsampler
+  :: downsample
+  :target_frame_rate                           5
+  :burst_frame_count                           0
+  :burst_frame_break                           0
+  :renumber_frames                             true
+
+connect from input.image
+        to   downsampler.input_1
+connect from input.file_name
+        to   downsampler.input_2
+connect from input.frame_rate
+        to   downsampler.frame_rate
+connect from input.timestamp
+        to   downsampler.timestamp
+
+process detector_input
+  :: image_filter
+  :filter:type                                 vxl_convert_image
+
+  block filter:vxl_convert_image
+    :format                                    byte
+    :force_three_channel                       true
+  endblock
+
+connect from downsampler.output_1
+        to   detector_input.image
+
+# =============================================================================
+
+process detector1
+  :: image_object_detector
+  :detector:type                               kwcoco_detector_kit
+
+  block detector:kwcoco_detector_kit
+    :package                                   [-PACKAGE-]
+    :device                                    cpu
+    :score_thresh                              0.30
+    :nms_thresh                                0.50
+  endblock
+
+connect from detector_input.image
+        to   detector1.image
+
+# =============================================================================
+
+process detector_merger
+  :: merge_detection_sets
+
+connect from detector1.detected_object_set
+        to   detector_merger.detected_object_set1
+
+process detector_output
+  :: refine_detections
+  :refiner:type                                nms
+
+  block refiner:nms
+    :max_overlap                               0.50
+    :nms_scale_factor                          1.0
+    :output_scale_factor                       1.0
+  endblock
+
+connect from detector_merger.detected_object_set
+        to   detector_output.detected_object_set
+
+# =============================================================================
+
+process detector_writer
+  :: detected_object_output
+
+  :file_name                                   computed_detections.csv
+  :writer:type                                 viame_csv
+
+connect from detector_output.detected_object_set
+        to   detector_writer.detected_object_set
+connect from downsampler.output_2
+        to   detector_writer.image_file_name

--- a/docker/viame_gpu_local.docker
+++ b/docker/viame_gpu_local.docker
@@ -92,7 +92,7 @@ cmake ../ -DCMAKE_BUILD_TYPE:STRING=Release \
 -DVIAME_ENABLE_WEB_EXCLUDES:BOOL=ON \
 -DVIAME_DOWNLOAD_MODELS:BOOL=ON \
 -DVIAME_DOWNLOAD_MODELS-PYTORCH:BOOL=OFF \
--DVIAME_DOWNLOAD_MODELS-GENERIC:BOOL=ON \
+-DVIAME_DOWNLOAD_MODELS-GENERIC:BOOL=OFF \
 -DVIAME_DOWNLOAD_MODELS-FISH:BOOL=ON \
 -DVIAME_DOWNLOAD_MODELS-ARCTIC-SEAL:BOOL=OFF \
 -DVIAME_DOWNLOAD_MODELS-HABCAM:BOOL=OFF \
@@ -103,7 +103,7 @@ cmake ../ -DCMAKE_BUILD_TYPE:STRING=Release \
 # loudly flag an incomplete build so a broken image is not mistaken for a good
 # one (a silent `make` failure here previously shipped an image with no VIAME).
 make -j$(nproc) || true
-if [ ! -e /viame/build/install/setup_viame.sh ]; then
+if [ ! -e /viame/build/build/src/viame-stamp/viame-install ]; then
   echo "########################################################################"
   echo "# WARNING: /viame/build/install/setup_viame.sh is missing."
   echo "# The VIAME build did NOT complete. Scroll up to the FIRST 'Error'"

--- a/docker/viame_gpu_local.docker
+++ b/docker/viame_gpu_local.docker
@@ -14,29 +14,32 @@ USER root
 WORKDIR /home
 
 RUN --mount=type=bind,target=/host-viame <<EOF
+#!/usr/bin/env bash
+set -e
 export DEBIAN_FRONTEND=noninteractive
-export TZ=Etc/UTC 
-apt-get update 
-apt-get install -y git 
+export TZ=Etc/UTC
+apt-get update
+apt-get install -y git wget
 
 # Clone from the host machine to the new docker repo.
-git clone --single-branch --dissociate /host-viame /viame 
+git clone --single-branch --dissociate /host-viame /viame
 
+# The old per-step helper scripts (build_server_deps_apt.sh /
+# build_server_linux_cmake.sh) were consolidated into
+# build_common_functions.sh (VIAME commit b7461a56e). Source it and call the
+# functions instead. This RUN executes under bash (note the shebang above)
+# because those helpers use bash features.
+cd /viame/cmake
+source /viame/cmake/build_common_functions.sh
 
-cd /viame/cmake 
+# Fletch / VIAME / CMake system deps, then CMake and Node (for the DIVE build)
+install_system_deps apt
+install_cmake
+install_nodejs 22
 
-# Fletch, VIAME, CMAKE system deps
-/viame/cmake/build_server_deps_apt.sh
-
-# Install CMAKE
-/viame/cmake/build_server_linux_cmake.sh
-
-# Update VIAME sub git deps
-cd /viame/
-git submodule update --init --recursive
-
-mkdir -p /viame/build
-cd /viame/build
+# Update VIAME sub git deps, then create + enter the build directory
+update_git_submodules /viame
+setup_build_directory /viame
 
 # Add VIAME and CUDA paths to build
 export PATH=$PATH:/usr/local/cuda/bin:/viame/build/install/bin
@@ -124,7 +127,11 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 RUN <<EOF
 # https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/
-__doc__='
+# Notes kept in the image (visible via `docker history`). Wrapped in a
+# quoted-delimiter heredoc fed to ':' (a no-op) so apostrophes and the
+# embedded sed/python single quotes below stay literal and never break the
+# build the way a single-quoted __doc__='...' string would.
+: <<'__doc__'
 
 This is a variant of ``viame_gpu_sam.docker`` that builds using the local checkout
 
@@ -313,5 +320,5 @@ first
 
 Now, run through the commands in the dockerfile manually.
 
-'
+__doc__
 EOF

--- a/docker/viame_gpu_local.docker
+++ b/docker/viame_gpu_local.docker
@@ -71,7 +71,7 @@ cmake ../ -DCMAKE_BUILD_TYPE:STRING=Release \
 -DVIAME_ENABLE_PYTORCH-LEARN:BOOL=OFF \
 -DVIAME_ENABLE_MATLAB:BOOL=OFF \
 -DVIAME_ENABLE_OPENCV:BOOL=ON \
--DVIAME_OPENCV_VERSION:STRING=3.4.0 \
+-DVIAME_OPENCV_VERSION:STRING=4.9.0 \
 -DVIAME_ENABLE_PYTHON:BOOL=ON \
 -DVIAME_BUILD_PYTHON_FROM_SOURCE:BOOL=ON \
 -DVIAME_ENABLE_PYTORCH:BOOL=ON \
@@ -98,8 +98,20 @@ cmake ../ -DCMAKE_BUILD_TYPE:STRING=Release \
 -DVIAME_DOWNLOAD_MODELS-HABCAM:BOOL=OFF \
 -DVIAME_DOWNLOAD_MODELS-MOUSS:BOOL=OFF
 
-# Perform multi-threaded build
+# Perform multi-threaded build. Keep || true so the image is still produced
+# for warm-start dev iteration even if the (long) compile is incomplete -- but
+# loudly flag an incomplete build so a broken image is not mistaken for a good
+# one (a silent `make` failure here previously shipped an image with no VIAME).
 make -j$(nproc) || true
+if [ ! -e /viame/build/install/setup_viame.sh ]; then
+  echo "########################################################################"
+  echo "# WARNING: /viame/build/install/setup_viame.sh is missing."
+  echo "# The VIAME build did NOT complete. Scroll up to the FIRST 'Error'"
+  echo "# (CMake Error / make *** Error) -- that is the real failure to fix."
+  echo "# The image was still produced for warm-start iteration, but VIAME"
+  echo "# will not run until the build is repaired and 'make' is re-run inside."
+  echo "########################################################################"
+fi
 EOF
 
 RUN <<EOF

--- a/docker/viame_gpu_local.docker
+++ b/docker/viame_gpu_local.docker
@@ -105,7 +105,7 @@ cmake ../ -DCMAKE_BUILD_TYPE:STRING=Release \
 make -j$(nproc) || true
 if [ ! -e /viame/build/build/src/viame-stamp/viame-install ]; then
   echo "########################################################################"
-  echo "# WARNING: /viame/build/install/setup_viame.sh is missing."
+  echo "# WARNING: the viame-install stamp is missing -- VIAME packages unbuilt."
   echo "# The VIAME build did NOT complete. Scroll up to the FIRST 'Error'"
   echo "# (CMake Error / make *** Error) -- that is the real failure to fix."
   echo "# The image was still produced for warm-start iteration, but VIAME"
@@ -134,8 +134,14 @@ chown -R 1099:1099 /opt/noaa/viame
 
 EOF
 
-ENV PATH=/usr/local/cuda/bin:$PATH
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+ENV PATH=/viame/build/install/bin:/usr/local/cuda/bin:$PATH
+ENV LD_LIBRARY_PATH=/viame/build/install/lib:/viame/build/install/lib/python3.10:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+# Persist the build include paths (Python.h etc.) so an in-container rebuild
+# works in a fresh shell. The build RUN above sets these locally, but they were
+# not persisted, so `make` in a `docker run ... bash` shell could not find
+# <Python.h> when (re)compiling the C++ plugins.
+ENV C_INCLUDE_PATH=/viame/build/install/include/python3.10
+ENV CPLUS_INCLUDE_PATH=/viame/build/install/include/python3.10
 
 RUN <<EOF
 # https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/

--- a/docker/viame_gpu_local_dev.docker
+++ b/docker/viame_gpu_local_dev.docker
@@ -121,7 +121,7 @@ cmake ../ $EXTRA -DCMAKE_BUILD_TYPE:STRING=Release \
 -DVIAME_ENABLE_WEB_EXCLUDES:BOOL=ON \
 -DVIAME_DOWNLOAD_MODELS:BOOL=ON \
 -DVIAME_DOWNLOAD_MODELS-PYTORCH:BOOL=OFF \
--DVIAME_DOWNLOAD_MODELS-GENERIC:BOOL=ON \
+-DVIAME_DOWNLOAD_MODELS-GENERIC:BOOL=OFF \
 -DVIAME_DOWNLOAD_MODELS-FISH:BOOL=ON \
 -DVIAME_DOWNLOAD_MODELS-ARCTIC-SEAL:BOOL=OFF \
 -DVIAME_DOWNLOAD_MODELS-HABCAM:BOOL=OFF \
@@ -151,7 +151,7 @@ RUN <<EOF
 #!/usr/bin/env bash
 cd /viame/build
 make -j"$(nproc)" || true
-if [ ! -e /viame/build/install/setup_viame.sh ]; then
+if [ ! -e /viame/build/build/src/viame-stamp/viame-install ]; then
   echo "########################################################################"
   echo "# WARNING: /viame/build/install/setup_viame.sh is missing."
   echo "# The VIAME build did NOT complete. Scroll up to the FIRST 'Error'"

--- a/docker/viame_gpu_local_dev.docker
+++ b/docker/viame_gpu_local_dev.docker
@@ -153,9 +153,9 @@ cd /viame/build
 make -j"$(nproc)" || true
 if [ ! -e /viame/build/build/src/viame-stamp/viame-install ]; then
   echo "########################################################################"
-  echo "# WARNING: /viame/build/install/setup_viame.sh is missing."
-  echo "# The VIAME build did NOT complete. Scroll up to the FIRST 'Error'"
-  echo "# (CMake Error / make *** Error) -- that is the real failure to fix."
+  echo "# WARNING: the viame-install stamp is missing -- the VIAME package layer"
+  echo "# did NOT finish. Scroll up to the FIRST 'Error' (CMake Error /"
+  echo "# make *** Error) -- that is the real failure to fix."
   echo "# Re-running 'docker build' resumes from the cached deps/fletch/kwiver"
   echo "# layers, so you do not pay for those again."
   echo "########################################################################"
@@ -204,6 +204,24 @@ GPU compute capability so PyTorch is not compiled for 8 architectures:
 If a build is interrupted (or a layer fails), just run the SAME command again:
 BuildKit reuses the cached deps / fletch / kwiver layers and resumes from the
 first incomplete layer. You do not re-pay for what already finished.
+
+Resume / finish a partial build from inside the container
+---------------------------------------------------------
+This image bakes the build env (PATH, LD_LIBRARY_PATH, C_INCLUDE_PATH for the
+from-source <Python.h>), so an in-container `make` Just Works -- unlike the
+older viame_gpu_local.docker, where a fresh shell must re-export those by hand
+or the C++ plugins fail with "Python.h: No such file or directory". To finish
+or repair a build without rebuilding the image:
+
+.. code:: bash
+
+    cd /viame/build
+    cmake ../                       # re-validate config; add -D... to change flags
+    make -j"$(nproc)"               # fletch / pytorch / kwiver already built are reused
+    ls build/src/viame-stamp/viame-install && echo "VIAME PACKAGE BUILT"
+
+    # persist the finished build (run from the host, in another terminal):
+    #   docker commit <container> viame:viame-gpu-local-dev
 
 Run (mount the host checkout for iteration)
 -------------------------------------------

--- a/docker/viame_gpu_local_dev.docker
+++ b/docker/viame_gpu_local_dev.docker
@@ -1,0 +1,260 @@
+# syntax=docker/dockerfile:1.5.0
+##############################################################################
+# Layered, resumable dev build of VIAME from the local checkout.
+#
+# This is a more efficient sibling of viame_gpu_local.docker. Same build, but:
+#
+#   * The one giant build RUN is split into separately-cached layers
+#       deps -> clone -> configure -> fletch -> kwiver -> pytorch+packages
+#     so a killed/failed build RESUMES from the last completed layer instead of
+#     starting over (the expensive fletch + kwiver layers stay cached).
+#   * CUDA_ARCHITECTURES is a build-arg: by default VIAME compiles PyTorch for
+#     ~8 GPU archs (6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0 ...). Limit it to YOUR GPU
+#     to cut the PyTorch-from-source compile (the long pole) several-fold.
+#   * The warm /viame + /viame/build tree is baked in, so day-to-day you mount
+#     your host checkout and run an INCREMENTAL `make` inside the container
+#     (see the dev-loop notes at the bottom of this file).
+##############################################################################
+FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
+
+USER root
+WORKDIR /home
+
+# Tunables (override with --build-arg). CUDA_ARCHITECTURES empty => VIAME's
+# (broad, slow) default; set it to your GPU's compute capability for a much
+# faster PyTorch build, e.g. --build-arg CUDA_ARCHITECTURES="8.9".
+ARG CUDA_ARCHITECTURES=
+ARG VIAME_OPENCV_VERSION=4.9.0
+ARG VIAME_PYTORCH_VERSION=2.12.0
+ARG VIAME_BUILD_LIMIT_NINJA=ON
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+# Build/runtime paths, set once so every build layer below inherits them.
+ENV PATH=/usr/local/cuda/bin:/viame/build/install/bin:$PATH
+ENV LD_LIBRARY_PATH=/viame/build/install/lib:/viame/build/install/lib/python3.10:/usr/local/cuda/lib64
+ENV C_INCLUDE_PATH=/viame/build/install/include/python3.10
+ENV CPLUS_INCLUDE_PATH=/viame/build/install/include/python3.10
+
+# ---------------------------------------------------------------------------
+# Layer 1: system deps + CMake + Node. Depends only on cmake/ (not the whole
+# repo) so it stays cached across source changes. Uses the consolidated
+# build_common_functions.sh helpers (the old per-step scripts were removed).
+# ---------------------------------------------------------------------------
+RUN --mount=type=bind,source=cmake,target=/host-cmake <<EOF
+#!/usr/bin/env bash
+set -e
+apt-get update
+apt-get install -y git wget rsync
+source /host-cmake/build_common_functions.sh
+install_system_deps apt
+install_cmake
+install_nodejs 22
+EOF
+
+# ---------------------------------------------------------------------------
+# Layer 2: clone the host checkout + submodules into the image. Bind-mount
+# cache semantics freeze this at first build; day-to-day you re-sync the host
+# into /viame from inside the running container (see notes at the bottom).
+# ---------------------------------------------------------------------------
+RUN --mount=type=bind,target=/host-viame <<EOF
+#!/usr/bin/env bash
+set -e
+git clone --single-branch --dissociate /host-viame /viame
+cd /viame
+git submodule update --init --recursive
+mkdir -p /viame/build
+EOF
+
+# ---------------------------------------------------------------------------
+# Layer 3: configure (cheap; its own layer so re-configuring doesn't rebuild
+# the deps). OpenCV 4.9.0 is required for CMake 4.x (3.4.0 hard-errors).
+# ---------------------------------------------------------------------------
+RUN <<EOF
+#!/usr/bin/env bash
+set -e
+cd /viame/build
+EXTRA=""
+if [ -n "${CUDA_ARCHITECTURES}" ]; then
+  EXTRA="-DCUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}"
+  echo "[configure] limiting CUDA archs to: ${CUDA_ARCHITECTURES}"
+else
+  echo "[configure] CUDA_ARCHITECTURES unset -> VIAME default (broad/slow). Pass --build-arg CUDA_ARCHITECTURES=<cap> to speed up PyTorch."
+fi
+cmake ../ $EXTRA -DCMAKE_BUILD_TYPE:STRING=Release \
+-DVIAME_BUILD_DEPENDENCIES:BOOL=ON \
+-DVIAME_FIXUP_BUNDLE:BOOL=OFF \
+-DVIAME_VERSION_RELEASE:BOOL=ON \
+-DVIAME_ENABLE_CUDA:BOOL=ON \
+-DVIAME_ENABLE_CUDNN:BOOL=ON \
+-DVIAME_ENABLE_DARKNET:BOOL=ON \
+-DVIAME_ENABLE_DIVE:BOOL=OFF \
+-DVIAME_ENABLE_DOCS:BOOL=OFF \
+-DVIAME_ENABLE_FFMPEG:BOOL=ON \
+-DVIAME_ENABLE_FFMPEG-X264:BOOL=ON \
+-DVIAME_ENABLE_GDAL:BOOL=OFF \
+-DVIAME_ENABLE_FLASK:BOOL=OFF \
+-DVIAME_ENABLE_ITK:BOOL=OFF \
+-DVIAME_ENABLE_KWANT:BOOL=ON \
+-DVIAME_ENABLE_KWIVER:BOOL=ON \
+-DVIAME_ENABLE_PYTORCH-LEARN:BOOL=OFF \
+-DVIAME_ENABLE_MATLAB:BOOL=OFF \
+-DVIAME_ENABLE_OPENCV:BOOL=ON \
+-DVIAME_OPENCV_VERSION:STRING=${VIAME_OPENCV_VERSION} \
+-DVIAME_ENABLE_PYTHON:BOOL=ON \
+-DVIAME_BUILD_PYTHON_FROM_SOURCE:BOOL=ON \
+-DVIAME_ENABLE_PYTORCH:BOOL=ON \
+-DVIAME_BUILD_PYTORCH_FROM_SOURCE:BOOL=ON \
+-DVIAME_PYTORCH_VERSION:STRING=${VIAME_PYTORCH_VERSION} \
+-DVIAME_BUILD_LIMIT_NINJA=${VIAME_BUILD_LIMIT_NINJA} \
+-DVIAME_BUILD_TORCHVISION_FROM_SOURCE=ON \
+-DVIAME_ENABLE_PYTORCH-VISION:BOOL=ON \
+-DVIAME_ENABLE_PYTORCH-MMDET:BOOL=OFF \
+-DVIAME_ENABLE_PYTORCH-NETHARN:BOOL=OFF \
+-DVIAME_ENABLE_PYTORCH-MIT-YOLO:BOOL=ON \
+-DVIAME_ENABLE_PYTORCH-SIAMMASK:BOOL=OFF \
+-DVIAME_ENABLE_PYTORCH-SAM2:BOOL=ON \
+-DVIAME_ENABLE_SEAL:BOOL=OFF \
+-DVIAME_ENABLE_TENSORFLOW:BOOL=OFF \
+-DVIAME_ENABLE_VIVIA:BOOL=OFF \
+-DVIAME_ENABLE_VXL:BOOL=ON \
+-DVIAME_ENABLE_WEB_EXCLUDES:BOOL=ON \
+-DVIAME_DOWNLOAD_MODELS:BOOL=ON \
+-DVIAME_DOWNLOAD_MODELS-PYTORCH:BOOL=OFF \
+-DVIAME_DOWNLOAD_MODELS-GENERIC:BOOL=ON \
+-DVIAME_DOWNLOAD_MODELS-FISH:BOOL=ON \
+-DVIAME_DOWNLOAD_MODELS-ARCTIC-SEAL:BOOL=OFF \
+-DVIAME_DOWNLOAD_MODELS-HABCAM:BOOL=OFF \
+-DVIAME_DOWNLOAD_MODELS-MOUSS:BOOL=OFF
+EOF
+
+# ---------------------------------------------------------------------------
+# Layer 4: fletch (OpenCV / VXL / FFmpeg / ... the C++ third-party stack).
+# Its own layer because it is expensive and was the previous failure point;
+# once cached, later failures never rebuild it. No `|| true`: a fletch failure
+# SHOULD stop the build.
+# ---------------------------------------------------------------------------
+RUN cd /viame/build && make -j"$(nproc)" fletch
+
+# ---------------------------------------------------------------------------
+# Layer 5: kwiver (+ the from-source Python it depends on). Cached checkpoint.
+# ---------------------------------------------------------------------------
+RUN cd /viame/build && make -j"$(nproc)" kwiver
+
+# ---------------------------------------------------------------------------
+# Layer 6: everything else -- PyTorch + torchvision from source (the long
+# pole) and the VIAME packages/plugins. `|| true` keeps the warm image even if
+# the long compile is incomplete, but we flag an incomplete build loudly so a
+# broken image is never mistaken for a good one.
+# ---------------------------------------------------------------------------
+RUN <<EOF
+#!/usr/bin/env bash
+cd /viame/build
+make -j"$(nproc)" || true
+if [ ! -e /viame/build/install/setup_viame.sh ]; then
+  echo "########################################################################"
+  echo "# WARNING: /viame/build/install/setup_viame.sh is missing."
+  echo "# The VIAME build did NOT complete. Scroll up to the FIRST 'Error'"
+  echo "# (CMake Error / make *** Error) -- that is the real failure to fix."
+  echo "# Re-running 'docker build' resumes from the cached deps/fletch/kwiver"
+  echo "# layers, so you do not pay for those again."
+  echo "########################################################################"
+fi
+EOF
+
+# ---------------------------------------------------------------------------
+# Post-build: libsvm symlink fixup + expose the install under /opt/noaa/viame.
+# ---------------------------------------------------------------------------
+RUN <<EOF
+#!/usr/bin/env bash
+cd /viame/build
+# HACK: ensure the invalid libsvm symlink is not created (remove when fixed).
+rm -f install/lib/libsvm.so
+cp install/lib/libsvm.so.2 install/lib/libsvm.so 2>/dev/null || true
+mkdir -p /opt/noaa
+ln -sf /viame/build/install /opt/noaa/viame
+chown -R 1099:1099 /opt/noaa/viame 2>/dev/null || true
+EOF
+
+ENV PATH=/usr/local/cuda/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+
+RUN <<EOF
+# Notes kept in the image (visible via `docker history`). Wrapped in a
+# quoted-delimiter heredoc fed to ':' (a no-op) so apostrophes and embedded
+# shell/python quotes stay literal and never break the build.
+: <<'__doc__'
+
+Layered, resumable, mountable dev build of VIAME (variant of viame_gpu_local).
+
+Build
+-----
+From the VIAME repo root on the host. The recommended form auto-fills your
+GPU compute capability so PyTorch is not compiled for 8 architectures:
+
+.. code:: bash
+
+    cd $HOME/code/VIAME
+
+    DOCKER_BUILDKIT=1 docker build --progress=plain \
+        --build-arg CUDA_ARCHITECTURES="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | sort -u | paste -sd' ')" \
+        -t "viame:viame-gpu-local-dev" \
+        -f docker/viame_gpu_local_dev.docker .
+
+If a build is interrupted (or a layer fails), just run the SAME command again:
+BuildKit reuses the cached deps / fletch / kwiver layers and resumes from the
+first incomplete layer. You do not re-pay for what already finished.
+
+Run (mount the host checkout for iteration)
+-------------------------------------------
+.. code:: bash
+
+    docker run --gpus=all \
+        --shm-size=8g \
+        --volume "$HOME/code/VIAME:/host-viame" \
+        -it viame:viame-gpu-local-dev \
+        bash
+
+Rapid iteration loop (inside the container)
+-------------------------------------------
+The image already has a warm /viame/build tree. To pick up host edits and
+rebuild only what changed:
+
+.. code:: bash
+
+    git config --global --add safe.directory /host-viame
+    git config --global --add safe.directory /host-viame/.git
+
+    # Pull host edits (committed or not) into the container source tree.
+    rsync -a --delete --exclude build /host-viame/ /viame/
+
+    # Incremental build -- only changed targets recompile.
+    cd /viame/build
+    make -j"$(nproc)"
+
+Fastest path for PURE-PYTHON plugin edits (no compile needed) -- e.g. the
+kwcoco_detector_kit detector. Symlink the host file straight into the install
+so edits are live with zero rebuild:
+
+.. code:: bash
+
+    SP=/opt/noaa/viame/lib/python3.10/site-packages/viame/arrows/pytorch
+    ln -sf /host-viame/plugins/pytorch/kwcoco_detector_kit_detector.py "$SP/kwcoco_detector_kit_detector.py"
+
+Use VIAME
+---------
+.. code:: bash
+
+    source /opt/noaa/viame/setup_viame.sh
+    cd /opt/noaa/viame/examples/object_detection
+    viame ...   # run a pipeline
+
+Speed knobs
+-----------
+  --build-arg CUDA_ARCHITECTURES="8.9"   # your GPU only (biggest win)
+  --build-arg VIAME_BUILD_LIMIT_NINJA=OFF  # faster PyTorch on big-RAM hosts
+                                           # (namek has 177G; OOM-safe). Leave
+                                           # ON for <64G machines.
+
+__doc__
+EOF

--- a/plugins/pytorch/CMakeLists.txt
+++ b/plugins/pytorch/CMakeLists.txt
@@ -16,6 +16,14 @@ kwiver_add_python_module(
   pytorch
   kwcoco_detector_kit_detector )
 
+# Vendored OnnxPredictor (canonical copy lives in the kwcoco_detector_kit repo;
+# resync with that repo's dev/vendor_onnx_to_viame.py). Vendored so VIAME
+# inference does not depend on kwcoco_detector_kit being installed.
+kwiver_add_python_module(
+  ${CMAKE_CURRENT_SOURCE_DIR}/kwcoco_detector_kit_onnx_predictor.py
+  pytorch
+  kwcoco_detector_kit_onnx_predictor )
+
 if( VIAME_ENABLE_PYTORCH-LEARN )
   add_subdirectory( learn )
 endif()

--- a/plugins/pytorch/CMakeLists.txt
+++ b/plugins/pytorch/CMakeLists.txt
@@ -11,6 +11,11 @@ kwiver_add_python_module(
   pytorch
   kwcoco_train_detector )
 
+kwiver_add_python_module(
+  ${CMAKE_CURRENT_SOURCE_DIR}/kwcoco_detector_kit_detector.py
+  pytorch
+  kwcoco_detector_kit_detector )
+
 if( VIAME_ENABLE_PYTORCH-LEARN )
   add_subdirectory( learn )
 endif()

--- a/plugins/pytorch/kwcoco_detector_kit_detector.py
+++ b/plugins/pytorch/kwcoco_detector_kit_detector.py
@@ -26,7 +26,7 @@ Example:
 """
 from __future__ import annotations
 
-import scriptconfig as scfg
+import kwconf
 
 from kwiver.vital.algo import ImageObjectDetector
 from viame.pytorch.utilities import (
@@ -37,18 +37,18 @@ from viame.pytorch.utilities import (
 )
 
 
-class KwcocoDetectorKitConfig(scfg.DataConfig):
+class KwcocoDetectorKitConfig(kwconf.Config):
     """Configuration for KwcocoDetectorKitDetector."""
 
-    package = scfg.Value(None, help=(
+    package = kwconf.Value(None, help=(
         'Path to the exported ONNX package directory or .zip archive. '
         'Must contain a .onnx file and (optionally) a .modelspec.json sidecar.'
     ))
-    device = scfg.Value('cpu', help='onnxruntime device: "cpu", "cuda", "cuda:0"')
-    score_thresh = scfg.Value(None, type=float, help=(
+    device = kwconf.Value('cpu', help='onnxruntime device: "cpu", "cuda", "cuda:0"')
+    score_thresh = kwconf.Value(None, parser=float, help=(
         'Detection score threshold. Defaults to the modelspec value when None.'
     ))
-    nms_thresh = scfg.Value(None, type=float, help=(
+    nms_thresh = kwconf.Value(None, parser=float, help=(
         'NMS IoU threshold. Advisory only — NMS is baked into the ONNX graph.'
     ))
 

--- a/plugins/pytorch/kwcoco_detector_kit_detector.py
+++ b/plugins/pytorch/kwcoco_detector_kit_detector.py
@@ -103,7 +103,11 @@ class KwcocoDetectorKitDetector(ImageObjectDetector):
     # ------------------------------------------------------------------
 
     def _build_model(self):
-        from kwcoco_detector_kit.predictors.onnx import OnnxPredictor
+        # Vendored predictor — VIAME inference does NOT depend on
+        # kwcoco_detector_kit being installed. See the provenance header in
+        # kwcoco_detector_kit_onnx_predictor.py; resync with the kit's
+        # dev/vendor_onnx_to_viame.py.
+        from viame.pytorch.kwcoco_detector_kit_onnx_predictor import OnnxPredictor
         self._predictor = OnnxPredictor(
             self._config.package,
             device=self._config.device or 'cpu',

--- a/plugins/pytorch/kwcoco_detector_kit_detector.py
+++ b/plugins/pytorch/kwcoco_detector_kit_detector.py
@@ -1,0 +1,146 @@
+# This file is part of VIAME, and is distributed under an OSI-approved #
+# BSD 3-Clause License. See either the root top-level LICENSE file or  #
+# https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.    #
+"""
+VIAME ImageObjectDetector wrapping a kwcoco_detector_kit ONNX export.
+
+The kit's OnnxPredictor handles all inference; this file is a thin kwiver
+adapter. No PyTorch or DEIMv2 dependency — only onnxruntime + kwimage.
+
+Export a package with:
+    python -m kwcoco_detector_kit export-onnx <workdir>
+
+Then point the ``package`` config key at the resulting directory or .zip.
+
+Example:
+    >>> # xdoctest: +REQUIRES(env:VIAME_SMOKE)
+    >>> import sys, pathlib
+    >>> sys.path.insert(0, str(pathlib.Path('~/code/VIAME/plugins/pytorch').expanduser()))
+    >>> from kwcoco_detector_kit_detector import *  # NOQA
+    >>> package = '/data/users/jon.crall/kcd_sealion/workdirs/.../export/'
+    >>> image_data = KwcocoDetectorKitDetector.demo_image()
+    >>> self = KwcocoDetectorKitDetector()
+    >>> self.set_configuration(dict(package=package, device='cpu'))
+    >>> detected_objects = self.detect(image_data)
+    >>> print(f'found {len(detected_objects)} detections')
+"""
+from __future__ import annotations
+
+import scriptconfig as scfg
+
+from kwiver.vital.algo import ImageObjectDetector
+from viame.pytorch.utilities import (
+    image_to_rgb_numpy,
+    kwimage_to_kwiver_detections,
+    register_vital_algorithm,
+    vital_config_update,
+)
+
+
+class KwcocoDetectorKitConfig(scfg.DataConfig):
+    """Configuration for KwcocoDetectorKitDetector."""
+
+    package = scfg.Value(None, help=(
+        'Path to the exported ONNX package directory or .zip archive. '
+        'Must contain a .onnx file and (optionally) a .modelspec.json sidecar.'
+    ))
+    device = scfg.Value('cpu', help='onnxruntime device: "cpu", "cuda", "cuda:0"')
+    score_thresh = scfg.Value(None, type=float, help=(
+        'Detection score threshold. Defaults to the modelspec value when None.'
+    ))
+    nms_thresh = scfg.Value(None, type=float, help=(
+        'NMS IoU threshold. Advisory only — NMS is baked into the ONNX graph.'
+    ))
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.score_thresh is not None:
+            self.score_thresh = float(self.score_thresh)
+        if self.nms_thresh is not None:
+            self.nms_thresh = float(self.nms_thresh)
+
+
+class KwcocoDetectorKitDetector(ImageObjectDetector):
+    """
+    VIAME detector wrapping a kwcoco_detector_kit ONNX export.
+
+    Point ``package`` at the directory produced by ``python -m kwcoco_detector_kit
+    export-onnx`` — it contains a ``.onnx`` model and a ``.modelspec.json``
+    sidecar that describe all inference parameters (input size, preprocessing,
+    category names).  No PyTorch or DEIMv2 installation required.
+    """
+
+    def __init__(self):
+        ImageObjectDetector.__init__(self)
+        self._config = KwcocoDetectorKitConfig()
+        self._predictor = None
+
+    # ------------------------------------------------------------------
+    # kwiver config protocol
+    # ------------------------------------------------------------------
+
+    def get_configuration(self):
+        cfg = super(ImageObjectDetector, self).get_configuration()
+        for key, value in self._config.items():
+            cfg.set_value(key, str(value) if value is not None else '')
+        return cfg
+
+    def set_configuration(self, cfg_in):
+        cfg = self.get_configuration()
+        vital_config_update(cfg, cfg_in)
+        for key in self._config.keys():
+            raw = cfg.get_value(key)
+            self._config[key] = None if raw == '' else raw
+        self._config.__post_init__()
+        self._build_model()
+        return True
+
+    def check_configuration(self, cfg):
+        return cfg.has_value('package') and cfg.get_value('package') != ''
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _build_model(self):
+        from kwcoco_detector_kit.predictors.onnx import OnnxPredictor
+        self._predictor = OnnxPredictor(
+            self._config.package,
+            device=self._config.device or 'cpu',
+            score_thresh=self._config.score_thresh,
+            nms_thresh=self._config.nms_thresh,
+        )
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    def detect(self, image_data):
+        if self._predictor is None:
+            raise RuntimeError(
+                'KwcocoDetectorKitDetector: call set_configuration before detect'
+            )
+        rgb = image_to_rgb_numpy(image_data)
+        dets = self._predictor.predict_image_kwimage(rgb)
+        dets = dets.numpy()
+        return kwimage_to_kwiver_detections(dets)
+
+    # ------------------------------------------------------------------
+    # Convenience / smoke-test helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def demo_image(cls):
+        """Return a kwiver ImageContainer wrapping a synthetic test image."""
+        import numpy as np
+        from kwiver.vital.types import Image, ImageContainer
+        arr = np.zeros((64, 64, 3), dtype=np.uint8)
+        return ImageContainer(Image(arr))
+
+
+def __vital_algorithm_register__():
+    register_vital_algorithm(
+        KwcocoDetectorKitDetector,
+        'kwcoco_detector_kit',
+        'DEIMv2 / kwcoco_detector_kit ONNX detector',
+    )

--- a/plugins/pytorch/kwcoco_detector_kit_onnx_predictor.py
+++ b/plugins/pytorch/kwcoco_detector_kit_onnx_predictor.py
@@ -1,0 +1,313 @@
+# ============================================================================
+# VENDORED FILE -- DO NOT EDIT HERE.
+#
+# This is a vendored copy of the canonical OnnxPredictor from the
+# kwcoco_detector_kit repository. VIAME inference uses this copy so it does NOT
+# depend on kwcoco_detector_kit being importable -- the kit evolves quickly and
+# may intentionally break ONNX-package compatibility, so VIAME pins/resyncs on
+# purpose rather than tracking the kit live.
+#
+# The CANONICAL source lives in the kit at:
+#     kwcoco_detector_kit/predictors/onnx.py
+# Edit it THERE, then resync this copy with the kit's vendoring tool:
+#     # in the kwcoco_detector_kit repo:
+#     python dev/vendor_onnx_to_viame.py --viame-root /path/to/VIAME
+#
+# Provenance is recorded in the importable ``__vendored_provenance__`` dict
+# below. ``source_sha256`` is the hash of the canonical file's body; ``--check``
+# recomputes it to detect drift.
+# ============================================================================
+"""
+ONNX inference backend — wraps a kit-exported ONNX package for deployment
+without PyTorch.
+
+Requires:  onnxruntime, numpy, kwimage
+No-import: torch, DEIMv2, kwcoco, kwconf, yaml
+"""
+from __future__ import annotations
+
+__vendored_provenance__ = {
+    "source_repo": "kwcoco_detector_kit",
+    "source_path": "kwcoco_detector_kit/predictors/onnx.py",
+    "kit_git_sha": "9d31086dad829260eaaf4c5f986695a25bbdb116",
+    "kit_git_dirty": False,
+    "source_sha256": "fedfbe3bfa3b8d6fac2b2aca0c11169c6f41de430e2d1b15da478eb7eaea5515",
+    "vendored_at": "2026-06-30T20:24:02Z",
+    "vendor_tool": "dev/vendor_onnx_to_viame.py",
+}
+
+import json
+import os
+import tempfile
+import zipfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import numpy as np
+
+
+def _providers_for_device(device: str) -> list:
+    """Map a device string to an onnxruntime provider list."""
+    if device == "cpu":
+        return ["CPUExecutionProvider"]
+    import onnxruntime as ort
+    if "CUDAExecutionProvider" not in ort.get_available_providers():
+        print(
+            f"[OnnxPredictor] CUDAExecutionProvider not available "
+            f"for device={device!r}; falling back to CPU"
+        )
+        return ["CPUExecutionProvider"]
+    return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+
+def _cuda_device_id(device: str) -> int | None:
+    """Parse 'cuda' → 0, 'cuda:N' → N, 'cpu' → None."""
+    if device == "cpu":
+        return None
+    parts = device.split(":")
+    return int(parts[1]) if len(parts) == 2 else 0
+
+
+def _safe_extract_zip(src: Path, dst: Path) -> None:
+    dst = dst.resolve()
+    with zipfile.ZipFile(src, "r") as zf:
+        for member in zf.infolist():
+            target = (dst / member.filename).resolve()
+            if os.path.commonpath([str(dst), str(target)]) != str(dst):
+                raise RuntimeError(f"unsafe zip member path: {member.filename}")
+        zf.extractall(dst)
+
+
+@contextmanager
+def _open_onnx_package(package: Path) -> Iterator[tuple[Path, dict]]:
+    """Yield (onnx_fpath, spec_dict) for a directory, .zip, or bare .onnx path."""
+    tmp_ctx = None
+    try:
+        if package.is_dir():
+            root = package
+        elif package.suffix == ".zip":
+            tmp_ctx = tempfile.TemporaryDirectory()
+            root = Path(tmp_ctx.name)
+            _safe_extract_zip(package, root)
+        elif package.suffix == ".onnx":
+            root = package.parent
+        else:
+            root = package.parent
+
+        onnx_files = sorted(root.rglob("*.onnx"))
+        if not onnx_files:
+            raise FileNotFoundError(f"no .onnx file found under {package}")
+        onnx_fpath = onnx_files[0]
+
+        spec_fpath = onnx_fpath.with_suffix(".modelspec.json")
+        spec = json.loads(spec_fpath.read_text()) if spec_fpath.exists() else {}
+        yield onnx_fpath, spec
+    finally:
+        if tmp_ctx is not None:
+            tmp_ctx.cleanup()
+
+
+class OnnxPredictor:
+    """
+    Inference adapter for a kit-exported ONNX package.
+
+    Satisfies the :class:`~kwcoco_detector_kit.predictors._interface.DetectorPredictor`
+    protocol. Requires only ``onnxruntime``, ``numpy``, and ``kwimage`` — no PyTorch.
+
+    Args:
+        package: Path to the exported package directory, ``.zip`` archive, or bare
+            ``.onnx`` file. A directory or zip must contain a ``.onnx`` model and
+            (optionally) a ``.modelspec.json`` sidecar with inference parameters.
+        device: ``"cpu"`` (default), ``"cuda"``, or ``"cuda:N"``.
+        score_thresh: Detection score threshold. When given, overrides the value
+            from ``.modelspec.json``. Detections below this threshold are dropped.
+        nms_thresh: NMS IoU threshold (stored for reference; DEIMv2 ONNX already
+            runs NMS internally so this is not re-applied).
+        providers: Explicit onnxruntime provider list. When given, overrides ``device``.
+    """
+
+    def __init__(
+        self,
+        package: str | Path,
+        *,
+        device: str = "cpu",
+        score_thresh: float | None = None,
+        nms_thresh: float | None = None,
+        providers: list | None = None,
+    ):
+        import onnxruntime as ort
+
+        package = Path(package).expanduser()
+
+        with _open_onnx_package(package) as (onnx_fpath, spec):
+            inp = spec.get("input", {})
+            shape_hw = inp.get("shape_hw", [640, 640])
+            self._eval_h = int(shape_hw[0])
+            self._eval_w = int(shape_hw[1])
+
+            pre = spec.get("preprocess", {})
+            self._scale = float(pre.get("scale", 1.0 / 255.0))
+            self._mean = np.array(
+                pre.get("normalize_mean", [0.0, 0.0, 0.0]), dtype=np.float32
+            ).reshape(1, 1, 3)
+            self._std = np.array(
+                pre.get("normalize_std", [1.0, 1.0, 1.0]), dtype=np.float32
+            ).reshape(1, 1, 3)
+
+            post = spec.get("postprocess", {})
+            self._score_thresh = float(
+                score_thresh if score_thresh is not None
+                else post.get("score_thresh", 0.30)
+            )
+            self._nms_thresh = float(
+                nms_thresh if nms_thresh is not None
+                else post.get("nms_iou_thresh", 0.50)
+            )
+
+            meta = spec.get("meta", {})
+            self._category_names: list[str] = list(meta.get("category_names", []))
+
+            if providers is None:
+                providers = _providers_for_device(device)
+                device_id = _cuda_device_id(device)
+                if device_id is not None and "CUDAExecutionProvider" in providers:
+                    providers = [
+                        ("CUDAExecutionProvider", {"device_id": device_id}),
+                        "CPUExecutionProvider",
+                    ]
+
+            self._session = ort.InferenceSession(str(onnx_fpath), providers=providers)
+
+    # ------------------------------------------------------------------
+    # Protocol properties
+    # ------------------------------------------------------------------
+
+    @property
+    def eval_spatial_size(self) -> tuple[int, int]:
+        """(H, W) the model evaluates at."""
+        return (self._eval_h, self._eval_w)
+
+    @property
+    def category_names(self) -> list[str]:
+        return self._category_names
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _preprocess(self, image_np: np.ndarray) -> np.ndarray:
+        """Resize to eval size, normalise, and convert to NCHW float32."""
+        import kwimage
+
+        if image_np.ndim == 2:
+            image_np = np.repeat(image_np[..., None], 3, axis=-1)
+        elif image_np.shape[2] == 4:
+            image_np = image_np[..., :3]
+
+        try:
+            resized = kwimage.imresize(
+                image_np, dsize=(self._eval_w, self._eval_h), interpolation="area"
+            )
+        except NotImplementedError:
+            resized = kwimage.imresize(
+                image_np, dsize=(self._eval_w, self._eval_h), interpolation="linear"
+            )
+
+        img_f32 = resized.astype(np.float32) * self._scale
+        img_f32 = (img_f32 - self._mean) / self._std
+        return img_f32.transpose(2, 0, 1)[None, ...]  # (1, 3, H, W)
+
+    # ------------------------------------------------------------------
+    # Public inference methods
+    # ------------------------------------------------------------------
+
+    def predict_image(
+        self,
+        image_np: np.ndarray,
+        orig_size=None,
+    ) -> list[dict]:
+        """Score one image; return detections filtered by ``score_thresh``.
+
+        Args:
+            image_np: HxWx3 uint8 RGB array (grayscale 2-D and RGBA also accepted).
+            orig_size: ``(W, H)`` of the original image. Inferred from ``image_np``
+                when ``None``.
+
+        Returns:
+            List of ``{'label': int, 'bbox_xyxy': [x0, y0, x1, y1], 'score': float}``
+            dicts, ordered by model output (score-descending after internal NMS).
+        """
+        if orig_size is None:
+            h, w = image_np.shape[:2]
+            orig_size = (w, h)
+
+        nchw = self._preprocess(image_np)
+        W, H = int(orig_size[0]), int(orig_size[1])
+        orig_sizes = np.array([[W, H]], dtype=np.int64)
+
+        outputs = self._session.run(
+            None, {"images": nchw, "orig_target_sizes": orig_sizes}
+        )
+        labels_raw, boxes_raw, scores_raw = outputs[:3]
+        # Batch dimension: pick item 0. shapes (K,), (K, 4), (K,)
+        labels = labels_raw[0]
+        boxes = boxes_raw[0]
+        scores = scores_raw[0]
+
+        result: list[dict] = []
+        for k in range(int(scores.shape[0])):
+            score = float(scores[k])
+            if score < self._score_thresh:
+                continue
+            x0, y0, x1, y1 = (float(v) for v in boxes[k])
+            result.append({
+                "label": int(labels[k]),
+                "bbox_xyxy": [x0, y0, x1, y1],
+                "score": score,
+            })
+        return result
+
+    def predict_image_kwimage(
+        self,
+        image_np: np.ndarray,
+        orig_size=None,
+    ):
+        """Score one image; return a :class:`kwimage.Detections` object.
+
+        Richer return type used by the VIAME plugin. ``.classes`` is populated
+        from ``self.category_names``.
+
+        Args:
+            image_np: HxWx3 uint8 RGB array.
+            orig_size: ``(W, H)``; inferred from ``image_np`` when ``None``.
+
+        Returns:
+            :class:`kwimage.Detections` with ``.boxes`` (ltrb),
+            ``.scores``, ``.class_idxs``, and ``.classes``.
+        """
+        import kwimage
+
+        if orig_size is None:
+            h, w = image_np.shape[:2]
+            orig_size = (w, h)
+
+        nchw = self._preprocess(image_np)
+        W, H = int(orig_size[0]), int(orig_size[1])
+        orig_sizes = np.array([[W, H]], dtype=np.int64)
+
+        outputs = self._session.run(
+            None, {"images": nchw, "orig_target_sizes": orig_sizes}
+        )
+        labels_raw, boxes_raw, scores_raw = outputs[:3]
+        labels = labels_raw[0].astype(np.int32)
+        boxes = boxes_raw[0].astype(np.float32)
+        scores = scores_raw[0].astype(np.float32)
+
+        keep = scores >= self._score_thresh
+        return kwimage.Detections(
+            boxes=kwimage.Boxes(boxes[keep], "ltrb"),
+            scores=scores[keep],
+            class_idxs=labels[keep],
+            classes=self._category_names,
+        )

--- a/plugins/pytorch/tests/test_kwcoco_detector_kit_detector.py
+++ b/plugins/pytorch/tests/test_kwcoco_detector_kit_detector.py
@@ -1,0 +1,237 @@
+"""
+Smoke tests for kwcoco_detector_kit_detector.py — the VIAME plugin that wraps
+the kit's ONNX predictor.
+
+Requires
+--------
+- kwiver (``from kwiver.vital.algo import ImageObjectDetector``)
+- viame (``from viame.pytorch.utilities import ...``)
+- kwcoco_detector_kit installed in this Python environment
+- A real ONNX export for the integration-level tests
+
+Run from the VIAME checkout root::
+
+    pytest plugins/pytorch/tests/test_kwcoco_detector_kit_detector.py -v
+
+Or from anywhere with::
+
+    pytest /path/to/VIAME/plugins/pytorch/tests/test_kwcoco_detector_kit_detector.py -v
+
+Skip the GPU tests with::
+
+    pytest ... -m "not cuda"
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Make the pytorch plugin directory importable when running pytest directly
+_PLUGIN_DIR = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_DIR))
+
+# ---------------------------------------------------------------------------
+# Module-level guards — defined before pytestmark uses them
+# ---------------------------------------------------------------------------
+
+def _can_import(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _can_import("kwiver.vital.algo"),
+        reason="kwiver not installed",
+    ),
+    pytest.mark.skipif(
+        not _can_import("viame.pytorch.utilities"),
+        reason="viame Python package not installed",
+    ),
+    pytest.mark.skipif(
+        not _can_import("kwcoco_detector_kit"),
+        reason="kwcoco_detector_kit not installed",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_KCD_TRAINING_ROOT = Path(os.environ.get("KCD_TRAINING_ROOT",
+                                         "/data/users/jon.crall/kcd_sealion"))
+
+
+def _find_real_onnx_package() -> Path | None:
+    env = os.environ.get("KCD_TEST_ONNX_PACKAGE")
+    if env:
+        p = Path(env).expanduser()
+        if p.exists():
+            return p
+    if not _KCD_TRAINING_ROOT.exists():
+        return None
+    for candidate in sorted(_KCD_TRAINING_ROOT.rglob("*.onnx")):
+        if candidate.stat().st_size > 1_000_000:
+            return candidate.parent
+    return None
+
+
+def _make_kwiver_image(h=64, w=64):
+    """Synthetic kwiver ImageContainer (RGB uint8)."""
+    from kwiver.vital.types import Image, ImageContainer
+    arr = np.random.randint(0, 200, (h, w, 3), dtype=np.uint8)
+    return ImageContainer(Image(arr))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def detector_class():
+    from kwcoco_detector_kit_detector import KwcocoDetectorKitDetector
+    return KwcocoDetectorKitDetector
+
+
+@pytest.fixture(scope="module")
+def real_onnx_package() -> Path:
+    pkg = _find_real_onnx_package()
+    if pkg is None:
+        pytest.skip(
+            "No real ONNX export found. "
+            "Set KCD_TEST_ONNX_PACKAGE or run: "
+            "python -m kwcoco_detector_kit export-onnx <workdir>"
+        )
+    return pkg
+
+
+# ---------------------------------------------------------------------------
+# Tests: plugin import and structure
+# ---------------------------------------------------------------------------
+
+def test_plugin_imports():
+    """The plugin module can be imported without errors."""
+    import kwcoco_detector_kit_detector  # noqa: F401
+
+
+def test_plugin_exports_vital_register():
+    """__vital_algorithm_register__ is present and callable."""
+    from kwcoco_detector_kit_detector import __vital_algorithm_register__
+    assert callable(__vital_algorithm_register__)
+
+
+def test_detector_inherits_image_object_detector(detector_class):
+    from kwiver.vital.algo import ImageObjectDetector
+    assert issubclass(detector_class, ImageObjectDetector)
+
+
+def test_detector_instantiates(detector_class):
+    obj = detector_class()
+    assert obj is not None
+
+
+def test_detector_get_configuration_returns_keys(detector_class):
+    """get_configuration() exposes all expected config keys."""
+    obj = detector_class()
+    cfg = obj.get_configuration()
+    for key in ("package", "device", "score_thresh", "nms_thresh"):
+        assert cfg.has_value(key), f"config key {key!r} missing"
+
+
+def test_check_configuration_rejects_empty(detector_class):
+    """check_configuration returns False when package is unset."""
+    obj = detector_class()
+    cfg = obj.get_configuration()
+    assert not obj.check_configuration(cfg)
+
+
+def test_check_configuration_accepts_package(detector_class, tmp_path):
+    """check_configuration returns True when package is non-empty string."""
+    obj = detector_class()
+    cfg = obj.get_configuration()
+    cfg.set_value("package", str(tmp_path))
+    assert obj.check_configuration(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Tests: set_configuration + detect on real ONNX
+# ---------------------------------------------------------------------------
+
+@pytest.mark.requires_onnx
+def test_set_configuration_builds_predictor(detector_class, real_onnx_package):
+    """set_configuration loads the ONNX model without error."""
+    pytest.importorskip("onnxruntime")
+    obj = detector_class()
+    result = obj.set_configuration(dict(
+        package=str(real_onnx_package),
+        device="cpu",
+        score_thresh="0.30",
+    ))
+    assert result is True
+    assert obj._predictor is not None
+
+
+@pytest.mark.requires_onnx
+def test_detect_synthetic_image(detector_class, real_onnx_package):
+    """detect() runs on a synthetic kwiver image and returns a DetectedObjectSet."""
+    pytest.importorskip("onnxruntime")
+    from kwiver.vital.types import DetectedObjectSet
+
+    obj = detector_class()
+    obj.set_configuration(dict(
+        package=str(real_onnx_package),
+        device="cpu",
+        score_thresh="0.10",
+    ))
+
+    image_data = _make_kwiver_image(640, 640)
+    result = obj.detect(image_data)
+
+    assert isinstance(result, DetectedObjectSet)
+    print(f"  detect() returned {len(result)} detections on synthetic 640x640 image")
+
+
+@pytest.mark.requires_onnx
+def test_detect_returns_valid_boxes(detector_class, real_onnx_package):
+    """All returned detections have valid bounding boxes and scores in range."""
+    pytest.importorskip("onnxruntime")
+    obj = detector_class()
+    obj.set_configuration(dict(
+        package=str(real_onnx_package),
+        device="cpu",
+        score_thresh="0.05",
+    ))
+
+    image_data = _make_kwiver_image(640, 640)
+    result = obj.detect(image_data)
+
+    for det in result:
+        bb = det.bounding_box
+        assert bb.width() > 0, f"zero-width box: {bb}"
+        assert bb.height() > 0, f"zero-height box: {bb}"
+        assert 0.0 <= det.confidence <= 1.0, f"score out of range: {det.confidence}"
+
+
+@pytest.mark.cuda
+@pytest.mark.requires_onnx
+def test_detect_cuda_runs(detector_class, real_onnx_package):
+    """detect() runs with device=cuda when a GPU is available."""
+    import onnxruntime as ort
+    if "CUDAExecutionProvider" not in ort.get_available_providers():
+        pytest.skip("CUDAExecutionProvider not available")
+
+    obj = detector_class()
+    obj.set_configuration(dict(
+        package=str(real_onnx_package),
+        device="cuda",
+        score_thresh="0.30",
+    ))
+
+    image_data = _make_kwiver_image(640, 640)
+    result = obj.detect(image_data)
+    print(f"  CUDA detect() returned {len(result)} detections")


### PR DESCRIPTION
This PR is adding the process and pipelines necessary to perform inference with the models I've trained using kwcoco-detector-kit (http://github.com/Erotemic/kwcoco_detector_kit.git)

It also updates / adds docker files I was using to test locally.

For the inference code, I vendored the relevant files from kwcoco-detector-kit, so VIAME inference does not depend on it. There is one new dependency: kwconf, which is just the new version of scriptconfig. They can co-exist, but all scriptconfig code should eventually be migrated to kwconf. 