### PR TITLE
fix: Arctic seal IR yolo pipeline crash (closes #245)

### DIFF
--- a/configs/add-ons/arctic-seal/common_arctic_seal_ir_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/common_arctic_seal_ir_yolo_detector.pipe
@@ -9,7 +9,7 @@
 
 process thermal_detector_input
   :: image_filter
-  :filter:type                                 npy_percentile_norm
+  :filter:type                                 percentile_norm_npy
 
 process thermal_detector1
   :: image_object_detector


### PR DESCRIPTION
## 🔱 Reaping #245: Arctic seal IR yolo pipeline crash

### What changed
The filter type 'npy_percentile_norm' does not exist; the correct implementation name is 'percentile_norm_npy', as seen in train_aug_percentile_norm_npy.pipe. Changing to the proper name fixes the crash.

**Reaper confidence:** 95/100

### Files targeted
- `configs/add-ons/arctic-seal/common_arctic_seal_ir_yolo_detector.pipe`

### Fixability Score
**75/100** — Partial error log, likely bug but reproduction not fully detailed, small scope of missing filter



### Smith Review
The filter name 'npy_percentile_norm' is indeed a typo; the intended filter is 'percentile_norm_npy'. The change is safe and fixes the crash, assuming this filter exists and no other parameters need adjustment. Verify that the filter's default parameters are appropriate for the pipeline. (confidence: 95%)

### Tests
⚠️ Not run — untrusted test execution is disabled (draft PR)

---
Generated autonomously by **RepoReaper by PatchHive**.
Closes #245.

⚖ Judge: PatchHive Judge · ⚔ Reaper: PatchHive Reaper · ⬢ Smith: PatchHive Smith · 🔒 Gatekeeper: PatchHive Gatekeeper

*RepoReaper by PatchHive*