### PR TITLE
fix: Tracks only adjust CSV pipeline crash (closes #235)

### DIFF
--- a/configs/pipelines/filter_tracks_only_adjust_csv.pipe
+++ b/configs/pipelines/filter_tracks_only_adjust_csv.pipe
@@ -97,8 +97,6 @@ process detector_writer
 
 connect from downsampler2.output_3
         to   detector_writer.detected_object_set
-connect from downsampler2.timestamp
-        to   detector_writer.timestamp
 connect from image_writer.image_file_name
         to   detector_writer.image_file_name
 


### PR DESCRIPTION
## 🔱 Reaping #235: Tracks only adjust CSV pipeline crash

### What changed
Remove the invalid connection from downsampler2.timestamp to detector_writer.timestamp because the detector_writer process lacks that input port, causing a pipeline crash. This connection is not present in similar working pipelines and is only valid for track_writer.

**Reaper confidence:** 95/100

### Files targeted
- `configs/pipelines/filter_tracks_only_adjust_csv.pipe`

### Fixability Score
**80/100** — Clear reproduction and scope, expected vs actual, definite bug, but no stacktrace



### Smith Review
Correctly removes the invalid connection that caused the crash. The port exists only for track_writer, not detector_writer. This matches similar working pipelines. (confidence: 95%)

### Tests
⚠️ Not run — untrusted test execution is disabled (draft PR)

---
Generated autonomously by **RepoReaper by PatchHive**.
Closes #235.

⚖ Judge: PatchHive Judge · ⚔ Reaper: PatchHive Reaper · ⬢ Smith: PatchHive Smith · 🔒 Gatekeeper: PatchHive Gatekeeper

*RepoReaper by PatchHive*