### PR TITLE
Add MINIMA-LoFTR for automatic cross-modality alignment

### DIFF
--- a/plugins/core/CMakeLists.txt
+++ b/plugins/core/CMakeLists.txt
@@ -455,6 +455,11 @@ if( VIAME_ENABLE_PYTHON )
     interactive_stereo )
 
   kwiver_add_python_module(
+    ${CMAKE_CURRENT_SOURCE_DIR}/interactive_alignment.py
+    core
+    interactive_alignment )
+
+  kwiver_add_python_module(
     ${CMAKE_CURRENT_SOURCE_DIR}/interactive_service.py
     core
     interactive_service )

--- a/plugins/core/interactive_alignment.py
+++ b/plugins/core/interactive_alignment.py
@@ -78,14 +78,17 @@ def find_alignment_weights() -> Optional[str]:
 def _resolve_device(device: Optional[str]) -> str:
     import torch
 
+    if device is not None and device.startswith("cuda") \
+            and not torch.cuda.is_available():
+        # The host service defaults to cuda; degrade to the best available
+        # backend rather than silently landing on CPU.
+        device = "auto"
     if device in (None, "", "auto"):
         if torch.cuda.is_available():
             return "cuda"
         if getattr(torch.backends, "mps", None) is not None \
                 and torch.backends.mps.is_available():
             return "mps"
-        return "cpu"
-    if device.startswith("cuda") and not torch.cuda.is_available():
         return "cpu"
     return device
 

--- a/plugins/core/interactive_alignment.py
+++ b/plugins/core/interactive_alignment.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python
+# This file is part of VIAME, and is distributed under an OSI-approved
+# BSD 3-Clause License. See either the root top-level LICENSE file or
+# https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.
+
+"""
+Interactive Alignment Service backend (auto-align).
+
+Computes a homography between two camera images of the same scene — typically
+different modalities (EO/RGB vs thermal IR) — using the vendored MINIMA-LoFTR
+matcher (viame.pytorch.minima_loftr), a LoFTR fine-tuned on multimodal data
+that is robust to cross-spectral appearance changes.
+
+Hosted by viame.core.interactive_service; same newline-delimited JSON
+protocol. The model (11.5M params, ~44 MB weights) loads lazily on the first
+``auto_align`` request and stays resident for the process lifetime.
+
+Commands:
+  auto_align            {image_path_a, image_path_b, options?}
+                        -> {homography (3x3, A native px -> B native px),
+                            inliers [[ax, ay, bx, by], ...] (spatially spread,
+                            native px), num_matches, num_inliers,
+                            inlier_ratio, image_size_a, image_size_b,
+                            model, elapsed_ms}
+  get_alignment_status  -> {available, weights_path, loaded, device}
+
+Failures the caller can act on are returned as ``success: False`` with a
+machine-readable ``code``:
+  insufficient_matches   scene has too little structure for the matcher
+  low_confidence         matches found but RANSAC consensus is too weak
+  degenerate_homography  a consensus exists but the fit is not a sane warp
+"""
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+# Matcher input size: long side after resize, dims floored to /8 (LoFTR df).
+MATCH_SIZE = 640
+# 16-bit (or generally high-dynamic-range single-channel) inputs are
+# percentile-normalized so low-contrast IR frames still spread over 8 bits.
+NORM_PERCENTILES = (2.0, 98.0)
+
+DEFAULT_OPTIONS = {
+    # RANSAC reprojection threshold in *matcher-resolution* pixels (<=640).
+    "ransac_threshold": 2.0,
+    # Quality gate: reject before/after RANSAC.
+    "min_matches": 100,
+    "min_inliers": 30,
+    "min_inlier_ratio": 0.15,
+    # How many spatially-spread inlier correspondences to return.
+    "top_k": 24,
+    # LoFTR coarse match confidence threshold.
+    "match_threshold": 0.2,
+}
+
+
+def find_alignment_weights() -> Optional[str]:
+    """Locate minima_loftr.ckpt in the VIAME install (or override via env)."""
+    override = os.environ.get("VIAME_ALIGNMENT_WEIGHTS")
+    if override and Path(override).exists():
+        return override
+    viame_install = os.environ.get("VIAME_INSTALL")
+    if viame_install:
+        candidate = (
+            Path(viame_install) / "configs" / "pipelines" / "models"
+            / "minima_loftr.ckpt"
+        )
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def _resolve_device(device: Optional[str]) -> str:
+    import torch
+
+    if device in (None, "", "auto"):
+        if torch.cuda.is_available():
+            return "cuda"
+        if getattr(torch.backends, "mps", None) is not None \
+                and torch.backends.mps.is_available():
+            return "mps"
+        return "cpu"
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        return "cpu"
+    return device
+
+
+def _load_gray_norm(path: str) -> Tuple[np.ndarray, Tuple[int, int]]:
+    """Load any 8/16-bit gray/color image as normalized 8-bit grayscale.
+
+    Returns (gray uint8 HxW, (native_width, native_height)).
+    """
+    img = cv2.imread(path, cv2.IMREAD_UNCHANGED | cv2.IMREAD_ANYDEPTH)
+    if img is None:
+        raise ValueError(f"Could not read image: {path}")
+    h, w = img.shape[:2]
+    if img.ndim == 3:
+        # Color inputs are standard 8-bit imagery (BGR from cv2).
+        if img.shape[2] == 4:
+            img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+        if img.dtype != np.uint8:
+            img = cv2.normalize(img, None, 0, 255, cv2.NORM_MINMAX) \
+                .astype(np.uint8)
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    elif img.dtype == np.uint8:
+        gray = img
+    else:
+        # Single-channel high-bit-depth (16-bit IR): percentile normalize so
+        # frame-to-frame dynamic range differences don't crush contrast.
+        arr = img.astype(np.float32)
+        lo, hi = np.percentile(arr, NORM_PERCENTILES)
+        arr = np.clip((arr - lo) / max(hi - lo, 1e-6), 0.0, 1.0)
+        gray = (arr * 255.0).astype(np.uint8)
+    return gray, (w, h)
+
+
+def _spread_inliers(
+    kpts_a: np.ndarray,
+    kpts_b: np.ndarray,
+    conf: np.ndarray,
+    mask: np.ndarray,
+    size_a: Tuple[int, int],
+    top_k: int,
+    grid: int = 6,
+) -> List[List[float]]:
+    """Pick up to top_k inliers spatially spread over image A (grid buckets),
+    preferring higher-confidence matches within each bucket."""
+    idx = np.flatnonzero(mask)
+    if len(idx) == 0:
+        return []
+    idx = idx[np.argsort(-conf[idx])]  # best confidence first
+    w, h = size_a
+    picked: List[int] = []
+    seen = set()
+    for i in idx:
+        cell = (
+            min(int(kpts_a[i, 0] / w * grid), grid - 1),
+            min(int(kpts_a[i, 1] / h * grid), grid - 1),
+        )
+        if cell not in seen:
+            seen.add(cell)
+            picked.append(int(i))
+        if len(picked) >= top_k:
+            break
+    for i in idx:  # top up if the grid didn't fill top_k
+        if len(picked) >= top_k:
+            break
+        if int(i) not in picked:
+            picked.append(int(i))
+    return [
+        [float(kpts_a[i, 0]), float(kpts_a[i, 1]),
+         float(kpts_b[i, 0]), float(kpts_b[i, 1])]
+        for i in picked
+    ]
+
+
+def _homography_is_sane(
+    H: np.ndarray, size_a: Tuple[int, int], size_b: Tuple[int, int]
+) -> bool:
+    """Reject non-finite / non-invertible / wildly-warping homographies."""
+    if H is None or not np.all(np.isfinite(H)):
+        return False
+    if abs(np.linalg.det(H)) < 1e-12:
+        return False
+    w, h = size_a
+    corners = np.array(
+        [[0, 0], [w, 0], [w, h], [0, h]], np.float64
+    ).reshape(-1, 1, 2)
+    warped = cv2.perspectiveTransform(corners, H).reshape(4, 2)
+    if not np.all(np.isfinite(warped)):
+        return False
+    # Warped corners must remain a convex quad with consistent winding.
+    def cross(o, a, b):
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+    signs = [
+        np.sign(cross(warped[i], warped[(i + 1) % 4], warped[(i + 2) % 4]))
+        for i in range(4)
+    ]
+    if len(set(signs)) != 1 or signs[0] == 0:
+        return False
+    # Area must be within a plausible range of the target image's area.
+    area = 0.5 * abs(sum(
+        warped[i][0] * warped[(i + 1) % 4][1]
+        - warped[(i + 1) % 4][0] * warped[i][1]
+        for i in range(4)
+    ))
+    wb, hb = size_b
+    ratio = area / float(wb * hb)
+    return 1e-2 < ratio < 1e2
+
+
+class InteractiveAlignmentService:
+    """Auto-align backend: MINIMA-LoFTR matching + MAGSAC homography."""
+
+    def __init__(
+        self,
+        weights_path: Optional[str] = None,
+        device: Optional[str] = None,
+    ):
+        self._weights_path = weights_path or find_alignment_weights()
+        self._requested_device = device
+        self._model = None
+        self._device: Optional[str] = None
+
+    # ---------------------------------------------------------------- model
+    def _log(self, message: str) -> None:
+        import sys
+        print(f"[InteractiveAlignment] {message}", file=sys.stderr, flush=True)
+
+    def _ensure_model(self):
+        if self._model is not None:
+            return self._model
+        if not self._weights_path or not Path(self._weights_path).exists():
+            raise ValueError(
+                "Alignment model weights not found (minima_loftr.ckpt); "
+                "expected in $VIAME_INSTALL/configs/pipelines/models or via "
+                "$VIAME_ALIGNMENT_WEIGHTS")
+        import torch
+        from copy import deepcopy
+        from viame.pytorch.minima_loftr import LoFTR, default_cfg
+
+        self._device = _resolve_device(self._requested_device)
+        self._log(
+            f"Loading MINIMA-LoFTR ({self._weights_path}) on {self._device}...")
+        start = time.time()
+        config = deepcopy(default_cfg)
+        state = torch.load(
+            self._weights_path, map_location="cpu", weights_only=False)
+        model = LoFTR(config=config)
+        model.load_state_dict(state["state_dict"], strict=True)
+        self._model = model.eval().to(self._device)
+        self._log(f"Alignment model ready in {time.time() - start:.1f}s")
+        return self._model
+
+    # ------------------------------------------------------------- matching
+    @staticmethod
+    def _to_match_tensor(gray: np.ndarray, device: str):
+        """Resize long side to MATCH_SIZE (dims /8) -> [1,1,H,W] in [0,1].
+
+        Returns (tensor, (sx, sy)) where s maps matcher coords -> native."""
+        import torch
+
+        h, w = gray.shape
+        scale = MATCH_SIZE / max(h, w)
+        nh = max(8, int(h * scale) // 8 * 8)
+        nw = max(8, int(w * scale) // 8 * 8)
+        resized = cv2.resize(gray, (nw, nh), interpolation=cv2.INTER_AREA)
+        tensor = torch.from_numpy(resized)[None, None].float().div(255.0)
+        return tensor.to(device), (w / nw, h / nh)
+
+    def auto_align(
+        self,
+        image_path_a: str,
+        image_path_b: str,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        import torch
+
+        opts = dict(DEFAULT_OPTIONS)
+        opts.update(options or {})
+        start = time.time()
+
+        model = self._ensure_model()
+        # CoarseMatching reads thr at forward time from its own attribute.
+        model.coarse_matching.thr = float(opts["match_threshold"])
+
+        device = self._device or "cpu"
+        gray_a, size_a = _load_gray_norm(image_path_a)
+        gray_b, size_b = _load_gray_norm(image_path_b)
+        img_a, scale_a = self._to_match_tensor(gray_a, device)
+        img_b, scale_b = self._to_match_tensor(gray_b, device)
+
+        batch = {"image0": img_a, "image1": img_b}
+        with torch.no_grad():
+            model(batch)
+        kpts_a = batch["mkpts0_f"].cpu().numpy()  # matcher coords, image A
+        kpts_b = batch["mkpts1_f"].cpu().numpy()
+        conf = batch["mconf"].cpu().numpy()
+        num_matches = len(kpts_a)
+
+        def failure(code: str, message: str, **extra) -> Dict[str, Any]:
+            result = {
+                "success": False,
+                "code": code,
+                "error": message,
+                "num_matches": num_matches,
+                "model": "minima_loftr",
+                "elapsed_ms": int((time.time() - start) * 1000),
+            }
+            result.update(extra)
+            return result
+
+        if num_matches < int(opts["min_matches"]):
+            return failure(
+                "insufficient_matches",
+                f"Only {num_matches} matches found (need "
+                f">={opts['min_matches']}); the scene may lack distinctive "
+                "structure — try a frame with more visual features.")
+
+        # RANSAC at matcher resolution (both images <= MATCH_SIZE) so the
+        # pixel threshold means the same thing regardless of native sizes.
+        cv2.setRNGSeed(0)
+        H_match, mask = cv2.findHomography(
+            kpts_a.astype(np.float64),
+            kpts_b.astype(np.float64),
+            cv2.USAC_MAGSAC,
+            ransacReprojThreshold=float(opts["ransac_threshold"]),
+            confidence=0.999999,
+            maxIters=10000,
+        )
+        if H_match is None or mask is None:
+            return failure(
+                "low_confidence",
+                "Could not find a consistent alignment among the matches.")
+        mask = mask.ravel().astype(bool)
+        num_inliers = int(mask.sum())
+        inlier_ratio = num_inliers / float(num_matches)
+        if num_inliers < int(opts["min_inliers"]) \
+                or inlier_ratio < float(opts["min_inlier_ratio"]):
+            return failure(
+                "low_confidence",
+                f"Alignment consensus too weak ({num_inliers} inliers, "
+                f"{inlier_ratio:.0%} of matches) — try a frame with more "
+                "distinctive structure.",
+                num_inliers=num_inliers,
+                inlier_ratio=round(inlier_ratio, 4))
+
+        # Map inliers to native pixel coordinates and refit there (plain
+        # least squares over inliers only, mirroring what a client-side fit
+        # over the returned correspondences would produce).
+        native_a = kpts_a * np.asarray(scale_a)
+        native_b = kpts_b * np.asarray(scale_b)
+        H_native, _ = cv2.findHomography(
+            native_a[mask].astype(np.float64),
+            native_b[mask].astype(np.float64),
+            0,
+        )
+        if not _homography_is_sane(H_native, size_a, size_b):
+            return failure(
+                "degenerate_homography",
+                "The fitted alignment is degenerate (matches may lie on a "
+                "line or the scene is unsuitable) — try another frame.",
+                num_inliers=num_inliers,
+                inlier_ratio=round(inlier_ratio, 4))
+
+        inliers = _spread_inliers(
+            native_a, native_b, conf, mask, size_a, int(opts["top_k"]))
+
+        return {
+            "success": True,
+            "homography": H_native.tolist(),
+            "inliers": inliers,
+            "num_matches": num_matches,
+            "num_inliers": num_inliers,
+            "inlier_ratio": round(inlier_ratio, 4),
+            "image_size_a": list(size_a),
+            "image_size_b": list(size_b),
+            "model": "minima_loftr",
+            "elapsed_ms": int((time.time() - start) * 1000),
+        }
+
+    # -------------------------------------------------------------- routing
+    def handle_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        command = request.get("command")
+        if command == "auto_align":
+            for key in ("image_path_a", "image_path_b"):
+                if not request.get(key):
+                    raise ValueError(f"auto_align requires '{key}'")
+                if not Path(request[key]).exists():
+                    raise ValueError(f"Image not found: {request[key]}")
+            return self.auto_align(
+                request["image_path_a"],
+                request["image_path_b"],
+                request.get("options"),
+            )
+        if command == "get_alignment_status":
+            return self.status()
+        raise ValueError(f"Unknown alignment command: {command}")
+
+    def status(self) -> Dict[str, Any]:
+        available = bool(
+            self._weights_path and Path(self._weights_path).exists())
+        return {
+            "success": True,
+            "available": available,
+            "weights_path": self._weights_path,
+            "loaded": self._model is not None,
+            "device": self._device,
+        }

--- a/plugins/core/interactive_alignment.py
+++ b/plugins/core/interactive_alignment.py
@@ -13,10 +13,10 @@ that is robust to cross-spectral appearance changes.
 
 Hosted by viame.core.interactive_service; same newline-delimited JSON
 protocol. The model (11.5M params, ~44 MB weights) loads lazily on the first
-``auto_align`` request and stays resident for the process lifetime.
+``register_images`` request and stays resident for the process lifetime.
 
 Commands:
-  auto_align            {image_path_a, image_path_b, options?}
+  register_images       {image_path_a, image_path_b, options?}
                         -> {homography (3x3, A native px -> B native px),
                             inliers [[ax, ay, bx, by], ...] (spatially spread,
                             native px), num_matches, num_inliers,
@@ -247,7 +247,7 @@ class InteractiveAlignmentService:
         stereo) is about to use its own model, so the ~44 MB matcher (plus
         whatever CUDA/MPS cache it held) yields its device memory rather than
         sitting resident alongside them. The model reloads lazily on the next
-        ``auto_align``. A no-op when nothing is loaded."""
+        ``register_images``. A no-op when nothing is loaded."""
         was_loaded = self._model is not None
         self._model = None
         if was_loaded:
@@ -398,10 +398,10 @@ class InteractiveAlignmentService:
     # -------------------------------------------------------------- routing
     def handle_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
         command = request.get("command")
-        if command == "auto_align":
+        if command == "register_images":
             for key in ("image_path_a", "image_path_b"):
                 if not request.get(key):
-                    raise ValueError(f"auto_align requires '{key}'")
+                    raise ValueError(f"register_images requires '{key}'")
                 if not Path(request[key]).exists():
                     raise ValueError(f"Image not found: {request[key]}")
             return self.auto_align(

--- a/plugins/core/interactive_alignment.py
+++ b/plugins/core/interactive_alignment.py
@@ -240,6 +240,34 @@ class InteractiveAlignmentService:
         self._log(f"Alignment model ready in {time.time() - start:.1f}s")
         return self._model
 
+    def unload(self) -> Dict[str, Any]:
+        """Drop the matcher model and release its device memory.
+
+        The host service calls this when a competing feature (segmentation or
+        stereo) is about to use its own model, so the ~44 MB matcher (plus
+        whatever CUDA/MPS cache it held) yields its device memory rather than
+        sitting resident alongside them. The model reloads lazily on the next
+        ``auto_align``. A no-op when nothing is loaded."""
+        was_loaded = self._model is not None
+        self._model = None
+        if was_loaded:
+            import gc
+            gc.collect()
+            # Return the freed allocations to the driver so other backends
+            # (segmentation/stereo) can actually reuse the VRAM, not just this
+            # process's caching allocator.
+            try:
+                import torch
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+                mps = getattr(torch.backends, "mps", None)
+                if mps is not None and mps.is_available():
+                    torch.mps.empty_cache()
+            except Exception:
+                pass
+            self._log("Alignment model unloaded")
+        return {"success": True, "unloaded": was_loaded}
+
     # ------------------------------------------------------------- matching
     @staticmethod
     def _to_match_tensor(gray: np.ndarray, device: str):

--- a/plugins/core/interactive_service.py
+++ b/plugins/core/interactive_service.py
@@ -63,6 +63,9 @@ from viame.core.interactive_stereo import (  # noqa: E402
     load_algorithm_from_config,
     find_viame_config as find_stereo_config,
 )
+from viame.core.interactive_alignment import (  # noqa: E402
+    InteractiveAlignmentService,
+)
 
 
 # Commands routed to the interactive-stereo backend. Everything else
@@ -79,6 +82,11 @@ STEREO_COMMANDS = {
 # disabling something that was never enabled, must stay cheap no-ops.
 STEREO_IDLE_COMMANDS = {"get_status", "cancel", "disable"}
 
+# Commands routed to the interactive-alignment (auto-align) backend. The
+# backend object itself is cheap to construct (its model loads lazily on the
+# first auto_align), so no idle-command special casing is needed.
+ALIGNMENT_COMMANDS = {"auto_align", "get_alignment_status"}
+
 # Segmentation cache-management commands that must NOT construct (load) the
 # segmentation backend / model before the user's first prediction.
 SEG_IDLE_COMMANDS = {"set_image", "clear_image"}
@@ -93,15 +101,18 @@ class InteractiveService:
         stereo_config: Optional[str],
         plugin_paths: Optional[List[str]] = None,
         device: Optional[str] = None,
+        alignment_weights: Optional[str] = None,
     ):
         self._segmentation_configs = segmentation_configs
         self._stereo_config = stereo_config
         self._plugin_paths = plugin_paths or []
         self._device = device
+        self._alignment_weights = alignment_weights
 
         # Lazily constructed sub-services (their models load lazily in turn).
         self._seg_service: Optional[InteractiveSegmentationService] = None
         self._stereo_service: Optional[InteractiveStereoService] = None
+        self._alignment_service: Optional[InteractiveAlignmentService] = None
 
         self._build_lock = threading.Lock()  # guards lazy construction
         self._send_lock = threading.Lock()   # serializes stdout writes
@@ -183,6 +194,19 @@ class InteractiveService:
                     f"({'epipolar' if matcher is not None else 'dense'} mode)")
         return self._stereo_service
 
+    def _ensure_alignment(self) -> InteractiveAlignmentService:
+        if self._alignment_service is not None:
+            return self._alignment_service
+        with self._build_lock:
+            if self._alignment_service is None:
+                # Cheap to construct; the matcher model loads lazily on the
+                # first auto_align request and stays resident afterwards.
+                self._alignment_service = InteractiveAlignmentService(
+                    weights_path=self._alignment_weights,
+                    device=self._device,
+                )
+        return self._alignment_service
+
     # ----------------------------------------------------------- routing
     def handle_request(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Route a request to the appropriate backend, building it on first use.
@@ -191,6 +215,9 @@ class InteractiveService:
         commands that defer their response to a background thread (which sends
         it later via the shared writer)."""
         command = request.get("command")
+
+        if command in ALIGNMENT_COMMANDS:
+            return self._ensure_alignment().handle_request(request)
 
         if command in STEREO_COMMANDS:
             # Don't spin up the stereo backend just to answer a status/lifecycle
@@ -320,6 +347,13 @@ def main():
         default="cuda",
         help="Device to run on (cuda, cpu, auto)",
     )
+    parser.add_argument(
+        "--alignment-weights",
+        default=None,
+        help="Path to the auto-align matcher weights (minima_loftr.ckpt). "
+             "If omitted, $VIAME_ALIGNMENT_WEIGHTS or "
+             "$VIAME_INSTALL/configs/pipelines/models is searched.",
+    )
     args = parser.parse_args()
 
     if args.viame_path:
@@ -339,6 +373,7 @@ def main():
         stereo_config=args.stereo_config,
         plugin_paths=args.plugin_path,
         device=args.device,
+        alignment_weights=args.alignment_weights,
     )
 
     try:

--- a/plugins/core/interactive_service.py
+++ b/plugins/core/interactive_service.py
@@ -89,8 +89,8 @@ STEREO_IDLE_COMMANDS = {"get_status", "cancel", "disable"}
 
 # Commands routed to the interactive-alignment (auto-align) backend. The
 # backend object itself is cheap to construct (its model loads lazily on the
-# first auto_align), so no idle-command special casing is needed.
-ALIGNMENT_COMMANDS = {"auto_align", "get_alignment_status"}
+# first register_images), so no idle-command special casing is needed.
+ALIGNMENT_COMMANDS = {"register_images", "get_alignment_status"}
 
 # Segmentation cache-management commands that must NOT construct (load) the
 # segmentation backend / model before the user's first prediction.
@@ -227,7 +227,7 @@ class InteractiveService:
         with self._build_lock:
             if self._alignment_service is None:
                 # Cheap to construct; the matcher model loads lazily on the
-                # first auto_align request and stays resident afterwards.
+                # first register_images request and stays resident afterwards.
                 self._alignment_service = InteractiveAlignmentService(
                     weights_path=self._alignment_weights,
                     device=self._device,
@@ -290,8 +290,9 @@ class InteractiveService:
         A no-op when auto-align never loaded a model (the backend may not even
         be constructed), so it is cheap to call on the hot path of every
         model-using segmentation/stereo request. The matcher reloads lazily on
-        the next auto_align, so the only cost is a re-load if the user returns
-        to auto-align after using the other feature -- which is exactly the
+        the next register_images, so the only cost is a re-load if the user
+        returns to auto-align after using the other feature -- which is
+        exactly the
         case where the two genuinely contend for memory."""
         svc = self._alignment_service
         if svc is None:

--- a/plugins/core/interactive_service.py
+++ b/plugins/core/interactive_service.py
@@ -52,20 +52,25 @@ warnings.filterwarnings(
     "ignore", message=r'The "\w+" class attribute of .* was deprecated in scriptconfig')
 logging.getLogger("torch.utils.cpp_extension").setLevel(logging.ERROR)
 
-from viame.core.interactive_segmentation import (  # noqa: E402
-    InteractiveSegmentationService,
-    load_algorithms_from_config,
-    find_viame_config as find_segmentation_config,
-    suppress_stdout,
-)
-from viame.core.interactive_stereo import (  # noqa: E402
-    InteractiveStereoService,
-    load_algorithm_from_config,
-    find_viame_config as find_stereo_config,
-)
+# The segmentation and stereo backends are imported lazily inside their
+# _ensure_* builders: both pull in kwiver / compiled bindings at import time
+# (interactive_stereo hard-imports viame.core._measurement), and a problem
+# there must fail that feature's first request with a JSON error rather than
+# kill the whole service -- the alignment backend below is pure Python
+# (torch/cv2) and stays usable regardless.
 from viame.core.interactive_alignment import (  # noqa: E402
     InteractiveAlignmentService,
 )
+
+
+def _suppress_stdout():
+    """Segmentation's stdout guard, or a no-op before that module loads."""
+    try:
+        from viame.core.interactive_segmentation import suppress_stdout
+        return suppress_stdout()
+    except ImportError:
+        import contextlib
+        return contextlib.nullcontext()
 
 
 # Commands routed to the interactive-stereo backend. Everything else
@@ -110,8 +115,8 @@ class InteractiveService:
         self._alignment_weights = alignment_weights
 
         # Lazily constructed sub-services (their models load lazily in turn).
-        self._seg_service: Optional[InteractiveSegmentationService] = None
-        self._stereo_service: Optional[InteractiveStereoService] = None
+        self._seg_service: Optional["InteractiveSegmentationService"] = None  # noqa: F821
+        self._stereo_service: Optional["InteractiveStereoService"] = None  # noqa: F821
         self._alignment_service: Optional[InteractiveAlignmentService] = None
 
         self._build_lock = threading.Lock()  # guards lazy construction
@@ -133,11 +138,17 @@ class InteractiveService:
         self._send({"id": request_id, "success": False, "error": error})
 
     # ------------------------------------------------- lazy construction
-    def _ensure_segmentation(self) -> InteractiveSegmentationService:
+    def _ensure_segmentation(self) -> "InteractiveSegmentationService":  # noqa: F821
         if self._seg_service is not None:
             return self._seg_service
         with self._build_lock:
             if self._seg_service is None:
+                from viame.core.interactive_segmentation import (
+                    InteractiveSegmentationService,
+                    load_algorithms_from_config,
+                    find_viame_config as find_segmentation_config,
+                    suppress_stdout,
+                )
                 configs = self._segmentation_configs
                 if not configs:
                     auto = find_segmentation_config()
@@ -164,18 +175,23 @@ class InteractiveService:
                 self._log("Segmentation backend ready")
         return self._seg_service
 
-    def _ensure_stereo(self) -> InteractiveStereoService:
+    def _ensure_stereo(self) -> "InteractiveStereoService":  # noqa: F821
         if self._stereo_service is not None:
             return self._stereo_service
         with self._build_lock:
             if self._stereo_service is None:
+                from viame.core.interactive_stereo import (
+                    InteractiveStereoService,
+                    load_algorithm_from_config,
+                    find_viame_config as find_stereo_config,
+                )
                 config = self._stereo_config or find_stereo_config()
                 if not config:
                     raise ValueError(
                         "No stereo config available "
                         "(interactive_stereo_default.conf); is VIAME_INSTALL set?")
                 self._log("Loading stereo backend...")
-                with suppress_stdout():
+                with _suppress_stdout():
                     stereo_algo, matcher, svc_cfg = load_algorithm_from_config(
                         config, self._plugin_paths)
                 if stereo_algo is None and matcher is None:
@@ -231,7 +247,7 @@ class InteractiveService:
         # click). This is the ONLY segmentation command that loads the model
         # ahead of an actual prediction.
         if command == "init_segmentation":
-            with suppress_stdout():
+            with _suppress_stdout():
                 self._ensure_segmentation().warmup()
             return {"success": True}
 

--- a/plugins/core/interactive_service.py
+++ b/plugins/core/interactive_service.py
@@ -96,6 +96,17 @@ ALIGNMENT_COMMANDS = {"auto_align", "get_alignment_status"}
 # segmentation backend / model before the user's first prediction.
 SEG_IDLE_COMMANDS = {"set_image", "clear_image"}
 
+# Commands that make a competing feature (segmentation or stereo) actually use
+# its model. The auto-align matcher, if resident, is released just before these
+# run so its device memory yields to the feature that needs it -- rather than
+# on alignment-panel close, which would thrash the model on every open/close.
+# Cheap idle/lifecycle commands (status polls, disable, image-cache management)
+# are intentionally excluded: they neither load nor run a model.
+SEG_MODEL_COMMANDS = {
+    "init_segmentation", "predict", "text_query", "refine", "stereo_segment",
+}
+STEREO_MODEL_COMMANDS = STEREO_COMMANDS - STEREO_IDLE_COMMANDS
+
 
 class InteractiveService:
     """Single stdin/stdout loop that lazily hosts both backends."""
@@ -240,6 +251,10 @@ class InteractiveService:
             # query (keeps single-camera sessions from ever loading stereo).
             if self._stereo_service is None and command in STEREO_IDLE_COMMANDS:
                 return self._stereo_idle_response(command)
+            # Stereo is about to use its model: free the auto-align matcher so
+            # its memory yields to stereo (no-op if nothing was aligned).
+            if command in STEREO_MODEL_COMMANDS:
+                self._release_alignment_memory("stereo")
             return self._ensure_stereo().handle_request(request)
 
         # Build + warm up the segmentation models. Sent when the user enters
@@ -247,6 +262,7 @@ class InteractiveService:
         # click). This is the ONLY segmentation command that loads the model
         # ahead of an actual prediction.
         if command == "init_segmentation":
+            self._release_alignment_memory("segmentation")
             with _suppress_stdout():
                 self._ensure_segmentation().warmup()
             return {"success": True}
@@ -256,11 +272,37 @@ class InteractiveService:
         if self._seg_service is None and command in SEG_IDLE_COMMANDS:
             return {"success": True}
 
+        # A real segmentation request will use (and, first time, load) the SAM
+        # model: free the auto-align matcher so its memory yields to it.
+        if command in SEG_MODEL_COMMANDS:
+            self._release_alignment_memory("segmentation")
+
         seg = self._ensure_segmentation()
         if command == "stereo_segment":
             # Reuse the one stereo backend (no second stereo model load).
             seg.set_stereo_warper(self._ensure_stereo())
         return seg.handle_request(request)
+
+    def _release_alignment_memory(self, feature: str) -> None:
+        """Free the resident auto-align matcher so ``feature`` (segmentation or
+        stereo) can use its device memory.
+
+        A no-op when auto-align never loaded a model (the backend may not even
+        be constructed), so it is cheap to call on the hot path of every
+        model-using segmentation/stereo request. The matcher reloads lazily on
+        the next auto_align, so the only cost is a re-load if the user returns
+        to auto-align after using the other feature -- which is exactly the
+        case where the two genuinely contend for memory."""
+        svc = self._alignment_service
+        if svc is None:
+            return
+        try:
+            result = svc.unload()
+        except Exception as e:  # releasing memory must never break the request
+            self._log(f"Alignment memory release failed (ignored): {e}")
+            return
+        if result.get("unloaded"):
+            self._log(f"Released auto-align model so {feature} can use its memory")
 
     @staticmethod
     def _stereo_idle_response(command: str) -> Dict[str, Any]:

--- a/plugins/pytorch/CMakeLists.txt
+++ b/plugins/pytorch/CMakeLists.txt
@@ -15,6 +15,8 @@ if( VIAME_ENABLE_PYTORCH-LEARN )
   add_subdirectory( learn )
 endif()
 
+add_subdirectory( minima_loftr )
+
 add_subdirectory( srnn )
 
 kwiver_add_python_module(

--- a/plugins/pytorch/minima_loftr/CMakeLists.txt
+++ b/plugins/pytorch/minima_loftr/CMakeLists.txt
@@ -1,0 +1,52 @@
+###
+# Vendored MINIMA-LoFTR matcher (inference only) — used by the interactive
+# alignment (auto-align) backend for cross-modality (e.g. EO<->IR) image
+# registration. See __init__.py for provenance and local modifications.
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+  pytorch/minima_loftr
+  __init__ )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/loftr.py
+  pytorch/minima_loftr
+  loftr )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/backbone/__init__.py
+  pytorch/minima_loftr/backbone
+  __init__ )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/backbone/resnet_fpn.py
+  pytorch/minima_loftr/backbone
+  resnet_fpn )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/loftr_module/__init__.py
+  pytorch/minima_loftr/loftr_module
+  __init__ )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/loftr_module/fine_preprocess.py
+  pytorch/minima_loftr/loftr_module
+  fine_preprocess )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/loftr_module/linear_attention.py
+  pytorch/minima_loftr/loftr_module
+  linear_attention )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/loftr_module/transformer.py
+  pytorch/minima_loftr/loftr_module
+  transformer )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/utils/__init__.py
+  pytorch/minima_loftr/utils
+  __init__ )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/utils/coarse_matching.py
+  pytorch/minima_loftr/utils
+  coarse_matching )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/utils/fine_matching.py
+  pytorch/minima_loftr/utils
+  fine_matching )
+
+kwiver_add_python_module( ${CMAKE_CURRENT_SOURCE_DIR}/utils/position_encoding.py
+  pytorch/minima_loftr/utils
+  position_encoding )

--- a/plugins/pytorch/minima_loftr/__init__.py
+++ b/plugins/pytorch/minima_loftr/__init__.py
@@ -1,0 +1,55 @@
+# This file is part of VIAME, and is distributed under an OSI-approved
+# BSD 3-Clause License. See either the root top-level LICENSE file or
+# https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.
+#
+# Vendored inference-only subset of MINIMA-LoFTR (Apache-2.0):
+#   https://github.com/LSXI7/LoFTR_minima  (src/loftr @ 9ba0871)
+#   https://github.com/LSXI7/MINIMA        (CVPR 2025, arXiv 2412.19412)
+# which is itself derived from LoFTR (Apache-2.0, https://github.com/zju3dv/LoFTR).
+#
+# Local modifications:
+#   - training-only modules (supervision, geometry) are not vendored
+#   - utils/fine_matching.py: kornia dependency replaced with local torch ops
+#   - this file: yacs config replaced with the equivalent plain dict
+
+from .loftr import LoFTR
+
+# Inference config equivalent to LoFTR_minima's lower_config(cvpr_ds_config),
+# with the post-outdoor_ds.ckpt coordinate fix that MINIMA weights require
+# (MINIMA/load_model.py sets temp_bug_fix=True for minima_loftr.ckpt).
+default_cfg = {
+    'backbone_type': 'ResNetFPN',
+    'resolution': (8, 2),
+    'fine_window_size': 5,
+    'fine_concat_coarse_feat': True,
+    'resnetfpn': {
+        'initial_dim': 128,
+        'block_dims': [128, 196, 256],
+    },
+    'coarse': {
+        'd_model': 256,
+        'd_ffn': 256,
+        'nhead': 8,
+        'layer_names': ['self', 'cross'] * 4,
+        'attention': 'linear',
+        'temp_bug_fix': True,
+    },
+    'match_coarse': {
+        'thr': 0.2,
+        'border_rm': 2,
+        'match_type': 'dual_softmax',
+        'dsmax_temperature': 0.1,
+        'skh_iters': 3,
+        'skh_init_bin_score': 1.0,
+        'skh_prefilter': True,
+        'train_coarse_percent': 0.4,
+        'train_pad_num_gt_min': 200,
+    },
+    'fine': {
+        'd_model': 128,
+        'd_ffn': 128,
+        'nhead': 8,
+        'layer_names': ['self', 'cross'] * 1,
+        'attention': 'linear',
+    },
+}

--- a/plugins/pytorch/minima_loftr/backbone/__init__.py
+++ b/plugins/pytorch/minima_loftr/backbone/__init__.py
@@ -1,0 +1,11 @@
+from .resnet_fpn import ResNetFPN_8_2, ResNetFPN_16_4
+
+
+def build_backbone(config):
+    if config['backbone_type'] == 'ResNetFPN':
+        if config['resolution'] == (8, 2):
+            return ResNetFPN_8_2(config['resnetfpn'])
+        elif config['resolution'] == (16, 4):
+            return ResNetFPN_16_4(config['resnetfpn'])
+    else:
+        raise ValueError(f"LOFTR.BACKBONE_TYPE {config['backbone_type']} not supported.")

--- a/plugins/pytorch/minima_loftr/backbone/resnet_fpn.py
+++ b/plugins/pytorch/minima_loftr/backbone/resnet_fpn.py
@@ -1,0 +1,199 @@
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def conv1x1(in_planes, out_planes, stride=1):
+    """1x1 convolution without padding"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, padding=0, bias=False)
+
+
+def conv3x3(in_planes, out_planes, stride=1):
+    """3x3 convolution with padding"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False)
+
+
+class BasicBlock(nn.Module):
+    def __init__(self, in_planes, planes, stride=1):
+        super().__init__()
+        self.conv1 = conv3x3(in_planes, planes, stride)
+        self.conv2 = conv3x3(planes, planes)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.bn2 = nn.BatchNorm2d(planes)
+        self.relu = nn.ReLU(inplace=True)
+
+        if stride == 1:
+            self.downsample = None
+        else:
+            self.downsample = nn.Sequential(
+                conv1x1(in_planes, planes, stride=stride),
+                nn.BatchNorm2d(planes)
+            )
+
+    def forward(self, x):
+        y = x
+        y = self.relu(self.bn1(self.conv1(y)))
+        y = self.bn2(self.conv2(y))
+
+        if self.downsample is not None:
+            x = self.downsample(x)
+
+        return self.relu(x+y)
+
+
+class ResNetFPN_8_2(nn.Module):
+    """
+    ResNet+FPN, output resolution are 1/8 and 1/2.
+    Each block has 2 layers.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        # Config
+        block = BasicBlock
+        initial_dim = config['initial_dim']
+        block_dims = config['block_dims']
+
+        # Class Variable
+        self.in_planes = initial_dim
+
+        # Networks
+        self.conv1 = nn.Conv2d(1, initial_dim, kernel_size=7, stride=2, padding=3, bias=False)
+        self.bn1 = nn.BatchNorm2d(initial_dim)
+        self.relu = nn.ReLU(inplace=True)
+
+        self.layer1 = self._make_layer(block, block_dims[0], stride=1)  # 1/2
+        self.layer2 = self._make_layer(block, block_dims[1], stride=2)  # 1/4
+        self.layer3 = self._make_layer(block, block_dims[2], stride=2)  # 1/8
+
+        # 3. FPN upsample
+        self.layer3_outconv = conv1x1(block_dims[2], block_dims[2])
+        self.layer2_outconv = conv1x1(block_dims[1], block_dims[2])
+        self.layer2_outconv2 = nn.Sequential(
+            conv3x3(block_dims[2], block_dims[2]),
+            nn.BatchNorm2d(block_dims[2]),
+            nn.LeakyReLU(),
+            conv3x3(block_dims[2], block_dims[1]),
+        )
+        self.layer1_outconv = conv1x1(block_dims[0], block_dims[1])
+        self.layer1_outconv2 = nn.Sequential(
+            conv3x3(block_dims[1], block_dims[1]),
+            nn.BatchNorm2d(block_dims[1]),
+            nn.LeakyReLU(),
+            conv3x3(block_dims[1], block_dims[0]),
+        )
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+    def _make_layer(self, block, dim, stride=1):
+        layer1 = block(self.in_planes, dim, stride=stride)
+        layer2 = block(dim, dim, stride=1)
+        layers = (layer1, layer2)
+
+        self.in_planes = dim
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        # ResNet Backbone
+        x0 = self.relu(self.bn1(self.conv1(x)))
+        x1 = self.layer1(x0)  # 1/2
+        x2 = self.layer2(x1)  # 1/4
+        x3 = self.layer3(x2)  # 1/8
+
+        # FPN
+        x3_out = self.layer3_outconv(x3)
+
+        x3_out_2x = F.interpolate(x3_out, scale_factor=2., mode='bilinear', align_corners=True)
+        x2_out = self.layer2_outconv(x2)
+        x2_out = self.layer2_outconv2(x2_out+x3_out_2x)
+
+        x2_out_2x = F.interpolate(x2_out, scale_factor=2., mode='bilinear', align_corners=True)
+        x1_out = self.layer1_outconv(x1)
+        x1_out = self.layer1_outconv2(x1_out+x2_out_2x)
+
+        return [x3_out, x1_out]
+
+
+class ResNetFPN_16_4(nn.Module):
+    """
+    ResNet+FPN, output resolution are 1/16 and 1/4.
+    Each block has 2 layers.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        # Config
+        block = BasicBlock
+        initial_dim = config['initial_dim']
+        block_dims = config['block_dims']
+
+        # Class Variable
+        self.in_planes = initial_dim
+
+        # Networks
+        self.conv1 = nn.Conv2d(1, initial_dim, kernel_size=7, stride=2, padding=3, bias=False)
+        self.bn1 = nn.BatchNorm2d(initial_dim)
+        self.relu = nn.ReLU(inplace=True)
+
+        self.layer1 = self._make_layer(block, block_dims[0], stride=1)  # 1/2
+        self.layer2 = self._make_layer(block, block_dims[1], stride=2)  # 1/4
+        self.layer3 = self._make_layer(block, block_dims[2], stride=2)  # 1/8
+        self.layer4 = self._make_layer(block, block_dims[3], stride=2)  # 1/16
+
+        # 3. FPN upsample
+        self.layer4_outconv = conv1x1(block_dims[3], block_dims[3])
+        self.layer3_outconv = conv1x1(block_dims[2], block_dims[3])
+        self.layer3_outconv2 = nn.Sequential(
+            conv3x3(block_dims[3], block_dims[3]),
+            nn.BatchNorm2d(block_dims[3]),
+            nn.LeakyReLU(),
+            conv3x3(block_dims[3], block_dims[2]),
+        )
+
+        self.layer2_outconv = conv1x1(block_dims[1], block_dims[2])
+        self.layer2_outconv2 = nn.Sequential(
+            conv3x3(block_dims[2], block_dims[2]),
+            nn.BatchNorm2d(block_dims[2]),
+            nn.LeakyReLU(),
+            conv3x3(block_dims[2], block_dims[1]),
+        )
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+    def _make_layer(self, block, dim, stride=1):
+        layer1 = block(self.in_planes, dim, stride=stride)
+        layer2 = block(dim, dim, stride=1)
+        layers = (layer1, layer2)
+
+        self.in_planes = dim
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        # ResNet Backbone
+        x0 = self.relu(self.bn1(self.conv1(x)))
+        x1 = self.layer1(x0)  # 1/2
+        x2 = self.layer2(x1)  # 1/4
+        x3 = self.layer3(x2)  # 1/8
+        x4 = self.layer4(x3)  # 1/16
+
+        # FPN
+        x4_out = self.layer4_outconv(x4)
+
+        x4_out_2x = F.interpolate(x4_out, scale_factor=2., mode='bilinear', align_corners=True)
+        x3_out = self.layer3_outconv(x3)
+        x3_out = self.layer3_outconv2(x3_out+x4_out_2x)
+
+        x3_out_2x = F.interpolate(x3_out, scale_factor=2., mode='bilinear', align_corners=True)
+        x2_out = self.layer2_outconv(x2)
+        x2_out = self.layer2_outconv2(x2_out+x3_out_2x)
+
+        return [x4_out, x2_out]

--- a/plugins/pytorch/minima_loftr/loftr.py
+++ b/plugins/pytorch/minima_loftr/loftr.py
@@ -1,0 +1,81 @@
+import torch
+import torch.nn as nn
+from einops.einops import rearrange
+
+from .backbone import build_backbone
+from .utils.position_encoding import PositionEncodingSine
+from .loftr_module import LocalFeatureTransformer, FinePreprocess
+from .utils.coarse_matching import CoarseMatching
+from .utils.fine_matching import FineMatching
+
+
+class LoFTR(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        # Misc
+        self.config = config
+
+        # Modules
+        self.backbone = build_backbone(config)
+        self.pos_encoding = PositionEncodingSine(
+            config['coarse']['d_model'],
+            temp_bug_fix=config['coarse']['temp_bug_fix'])
+        self.loftr_coarse = LocalFeatureTransformer(config['coarse'])
+        self.coarse_matching = CoarseMatching(config['match_coarse'])
+        self.fine_preprocess = FinePreprocess(config)
+        self.loftr_fine = LocalFeatureTransformer(config["fine"])
+        self.fine_matching = FineMatching()
+
+    def forward(self, data):
+        """ 
+        Update:
+            data (dict): {
+                'image0': (torch.Tensor): (N, 1, H, W)
+                'image1': (torch.Tensor): (N, 1, H, W)
+                'mask0'(optional) : (torch.Tensor): (N, H, W) '0' indicates a padded position
+                'mask1'(optional) : (torch.Tensor): (N, H, W)
+            }
+        """
+        # 1. Local Feature CNN
+        data.update({
+            'bs': data['image0'].size(0),
+            'hw0_i': data['image0'].shape[2:], 'hw1_i': data['image1'].shape[2:]
+        })
+
+        if data['hw0_i'] == data['hw1_i']:  # faster & better BN convergence
+            feats_c, feats_f = self.backbone(torch.cat([data['image0'], data['image1']], dim=0))
+            (feat_c0, feat_c1), (feat_f0, feat_f1) = feats_c.split(data['bs']), feats_f.split(data['bs'])
+        else:  # handle different input shapes
+            (feat_c0, feat_f0), (feat_c1, feat_f1) = self.backbone(data['image0']), self.backbone(data['image1'])
+
+        data.update({
+            'hw0_c': feat_c0.shape[2:], 'hw1_c': feat_c1.shape[2:],
+            'hw0_f': feat_f0.shape[2:], 'hw1_f': feat_f1.shape[2:]
+        })
+
+        # 2. coarse-level loftr module
+        # add featmap with positional encoding, then flatten it to sequence [N, HW, C]
+        feat_c0 = rearrange(self.pos_encoding(feat_c0), 'n c h w -> n (h w) c')
+        feat_c1 = rearrange(self.pos_encoding(feat_c1), 'n c h w -> n (h w) c')
+
+        mask_c0 = mask_c1 = None  # mask is useful in training
+        if 'mask0' in data:
+            mask_c0, mask_c1 = data['mask0'].flatten(-2), data['mask1'].flatten(-2)
+        feat_c0, feat_c1 = self.loftr_coarse(feat_c0, feat_c1, mask_c0, mask_c1)
+
+        # 3. match coarse-level
+        self.coarse_matching(feat_c0, feat_c1, data, mask_c0=mask_c0, mask_c1=mask_c1)
+
+        # 4. fine-level refinement
+        feat_f0_unfold, feat_f1_unfold = self.fine_preprocess(feat_f0, feat_f1, feat_c0, feat_c1, data)
+        if feat_f0_unfold.size(0) != 0:  # at least one coarse level predicted
+            feat_f0_unfold, feat_f1_unfold = self.loftr_fine(feat_f0_unfold, feat_f1_unfold)
+
+        # 5. match fine-level
+        self.fine_matching(feat_f0_unfold, feat_f1_unfold, data)
+
+    def load_state_dict(self, state_dict, *args, **kwargs):
+        for k in list(state_dict.keys()):
+            if k.startswith('matcher.'):
+                state_dict[k.replace('matcher.', '', 1)] = state_dict.pop(k)
+        return super().load_state_dict(state_dict, *args, **kwargs)

--- a/plugins/pytorch/minima_loftr/loftr_module/__init__.py
+++ b/plugins/pytorch/minima_loftr/loftr_module/__init__.py
@@ -1,0 +1,2 @@
+from .transformer import LocalFeatureTransformer
+from .fine_preprocess import FinePreprocess

--- a/plugins/pytorch/minima_loftr/loftr_module/fine_preprocess.py
+++ b/plugins/pytorch/minima_loftr/loftr_module/fine_preprocess.py
@@ -1,0 +1,59 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops.einops import rearrange, repeat
+
+
+class FinePreprocess(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+
+        self.config = config
+        self.cat_c_feat = config['fine_concat_coarse_feat']
+        self.W = self.config['fine_window_size']
+
+        d_model_c = self.config['coarse']['d_model']
+        d_model_f = self.config['fine']['d_model']
+        self.d_model_f = d_model_f
+        if self.cat_c_feat:
+            self.down_proj = nn.Linear(d_model_c, d_model_f, bias=True)
+            self.merge_feat = nn.Linear(2*d_model_f, d_model_f, bias=True)
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.kaiming_normal_(p, mode="fan_out", nonlinearity="relu")
+
+    def forward(self, feat_f0, feat_f1, feat_c0, feat_c1, data):
+        W = self.W
+        stride = data['hw0_f'][0] // data['hw0_c'][0]
+
+        data.update({'W': W})
+        if data['b_ids'].shape[0] == 0:
+            feat0 = torch.empty(0, self.W**2, self.d_model_f, device=feat_f0.device)
+            feat1 = torch.empty(0, self.W**2, self.d_model_f, device=feat_f0.device)
+            return feat0, feat1
+
+        # 1. unfold(crop) all local windows
+        feat_f0_unfold = F.unfold(feat_f0, kernel_size=(W, W), stride=stride, padding=W//2)
+        feat_f0_unfold = rearrange(feat_f0_unfold, 'n (c ww) l -> n l ww c', ww=W**2)
+        feat_f1_unfold = F.unfold(feat_f1, kernel_size=(W, W), stride=stride, padding=W//2)
+        feat_f1_unfold = rearrange(feat_f1_unfold, 'n (c ww) l -> n l ww c', ww=W**2)
+
+        # 2. select only the predicted matches
+        feat_f0_unfold = feat_f0_unfold[data['b_ids'], data['i_ids']]  # [n, ww, cf]
+        feat_f1_unfold = feat_f1_unfold[data['b_ids'], data['j_ids']]
+
+        # option: use coarse-level loftr feature as context: concat and linear
+        if self.cat_c_feat:
+            feat_c_win = self.down_proj(torch.cat([feat_c0[data['b_ids'], data['i_ids']],
+                                                   feat_c1[data['b_ids'], data['j_ids']]], 0))  # [2n, c]
+            feat_cf_win = self.merge_feat(torch.cat([
+                torch.cat([feat_f0_unfold, feat_f1_unfold], 0),  # [2n, ww, cf]
+                repeat(feat_c_win, 'n c -> n ww c', ww=W**2),  # [2n, ww, cf]
+            ], -1))
+            feat_f0_unfold, feat_f1_unfold = torch.chunk(feat_cf_win, 2, dim=0)
+
+        return feat_f0_unfold, feat_f1_unfold

--- a/plugins/pytorch/minima_loftr/loftr_module/linear_attention.py
+++ b/plugins/pytorch/minima_loftr/loftr_module/linear_attention.py
@@ -1,0 +1,81 @@
+"""
+Linear Transformer proposed in "Transformers are RNNs: Fast Autoregressive Transformers with Linear Attention"
+Modified from: https://github.com/idiap/fast-transformers/blob/master/fast_transformers/attention/linear_attention.py
+"""
+
+import torch
+from torch.nn import Module, Dropout
+
+
+def elu_feature_map(x):
+    return torch.nn.functional.elu(x) + 1
+
+
+class LinearAttention(Module):
+    def __init__(self, eps=1e-6):
+        super().__init__()
+        self.feature_map = elu_feature_map
+        self.eps = eps
+
+    def forward(self, queries, keys, values, q_mask=None, kv_mask=None):
+        """ Multi-Head linear attention proposed in "Transformers are RNNs"
+        Args:
+            queries: [N, L, H, D]
+            keys: [N, S, H, D]
+            values: [N, S, H, D]
+            q_mask: [N, L]
+            kv_mask: [N, S]
+        Returns:
+            queried_values: (N, L, H, D)
+        """
+        Q = self.feature_map(queries)
+        K = self.feature_map(keys)
+
+        # set padded position to zero
+        if q_mask is not None:
+            Q = Q * q_mask[:, :, None, None]
+        if kv_mask is not None:
+            K = K * kv_mask[:, :, None, None]
+            values = values * kv_mask[:, :, None, None]
+
+        v_length = values.size(1)
+        values = values / v_length  # prevent fp16 overflow
+        KV = torch.einsum("nshd,nshv->nhdv", K, values)  # (S,D)' @ S,V
+        Z = 1 / (torch.einsum("nlhd,nhd->nlh", Q, K.sum(dim=1)) + self.eps)
+        queried_values = torch.einsum("nlhd,nhdv,nlh->nlhv", Q, KV, Z) * v_length
+
+        return queried_values.contiguous()
+
+
+class FullAttention(Module):
+    def __init__(self, use_dropout=False, attention_dropout=0.1):
+        super().__init__()
+        self.use_dropout = use_dropout
+        self.dropout = Dropout(attention_dropout)
+
+    def forward(self, queries, keys, values, q_mask=None, kv_mask=None):
+        """ Multi-head scaled dot-product attention, a.k.a full attention.
+        Args:
+            queries: [N, L, H, D]
+            keys: [N, S, H, D]
+            values: [N, S, H, D]
+            q_mask: [N, L]
+            kv_mask: [N, S]
+        Returns:
+            queried_values: (N, L, H, D)
+        """
+
+        # Compute the unnormalized attention and apply the masks
+        QK = torch.einsum("nlhd,nshd->nlsh", queries, keys)
+        if kv_mask is not None:
+            QK.masked_fill_(~(q_mask[:, :, None, None] * kv_mask[:, None, :, None]), float('-inf'))
+
+        # Compute the attention and the weighted average
+        softmax_temp = 1. / queries.size(3)**.5  # sqrt(D)
+        A = torch.softmax(softmax_temp * QK, dim=2)
+        if self.use_dropout:
+            A = self.dropout(A)
+
+        queried_values = torch.einsum("nlsh,nshd->nlhd", A, values)
+
+        return queried_values.contiguous()

--- a/plugins/pytorch/minima_loftr/loftr_module/transformer.py
+++ b/plugins/pytorch/minima_loftr/loftr_module/transformer.py
@@ -1,0 +1,101 @@
+import copy
+import torch
+import torch.nn as nn
+from .linear_attention import LinearAttention, FullAttention
+
+
+class LoFTREncoderLayer(nn.Module):
+    def __init__(self,
+                 d_model,
+                 nhead,
+                 attention='linear'):
+        super(LoFTREncoderLayer, self).__init__()
+
+        self.dim = d_model // nhead
+        self.nhead = nhead
+
+        # multi-head attention
+        self.q_proj = nn.Linear(d_model, d_model, bias=False)
+        self.k_proj = nn.Linear(d_model, d_model, bias=False)
+        self.v_proj = nn.Linear(d_model, d_model, bias=False)
+        self.attention = LinearAttention() if attention == 'linear' else FullAttention()
+        self.merge = nn.Linear(d_model, d_model, bias=False)
+
+        # feed-forward network
+        self.mlp = nn.Sequential(
+            nn.Linear(d_model*2, d_model*2, bias=False),
+            nn.ReLU(True),
+            nn.Linear(d_model*2, d_model, bias=False),
+        )
+
+        # norm and dropout
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+
+    def forward(self, x, source, x_mask=None, source_mask=None):
+        """
+        Args:
+            x (torch.Tensor): [N, L, C]
+            source (torch.Tensor): [N, S, C]
+            x_mask (torch.Tensor): [N, L] (optional)
+            source_mask (torch.Tensor): [N, S] (optional)
+        """
+        bs = x.size(0)
+        query, key, value = x, source, source
+
+        # multi-head attention
+        query = self.q_proj(query).view(bs, -1, self.nhead, self.dim)  # [N, L, (H, D)]
+        key = self.k_proj(key).view(bs, -1, self.nhead, self.dim)  # [N, S, (H, D)]
+        value = self.v_proj(value).view(bs, -1, self.nhead, self.dim)
+        message = self.attention(query, key, value, q_mask=x_mask, kv_mask=source_mask)  # [N, L, (H, D)]
+        message = self.merge(message.view(bs, -1, self.nhead*self.dim))  # [N, L, C]
+        message = self.norm1(message)
+
+        # feed-forward network
+        message = self.mlp(torch.cat([x, message], dim=2))
+        message = self.norm2(message)
+
+        return x + message
+
+
+class LocalFeatureTransformer(nn.Module):
+    """A Local Feature Transformer (LoFTR) module."""
+
+    def __init__(self, config):
+        super(LocalFeatureTransformer, self).__init__()
+
+        self.config = config
+        self.d_model = config['d_model']
+        self.nhead = config['nhead']
+        self.layer_names = config['layer_names']
+        encoder_layer = LoFTREncoderLayer(config['d_model'], config['nhead'], config['attention'])
+        self.layers = nn.ModuleList([copy.deepcopy(encoder_layer) for _ in range(len(self.layer_names))])
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def forward(self, feat0, feat1, mask0=None, mask1=None):
+        """
+        Args:
+            feat0 (torch.Tensor): [N, L, C]
+            feat1 (torch.Tensor): [N, S, C]
+            mask0 (torch.Tensor): [N, L] (optional)
+            mask1 (torch.Tensor): [N, S] (optional)
+        """
+
+        assert self.d_model == feat0.size(2), "the feature number of src and transformer must be equal"
+
+        for layer, name in zip(self.layers, self.layer_names):
+            if name == 'self':
+                feat0 = layer(feat0, feat0, mask0, mask0)
+                feat1 = layer(feat1, feat1, mask1, mask1)
+            elif name == 'cross':
+                feat0 = layer(feat0, feat1, mask0, mask1)
+                feat1 = layer(feat1, feat0, mask1, mask0)
+            else:
+                raise KeyError
+
+        return feat0, feat1

--- a/plugins/pytorch/minima_loftr/utils/coarse_matching.py
+++ b/plugins/pytorch/minima_loftr/utils/coarse_matching.py
@@ -1,0 +1,261 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops.einops import rearrange
+
+INF = 1e9
+
+def mask_border(m, b: int, v):
+    """ Mask borders with value
+    Args:
+        m (torch.Tensor): [N, H0, W0, H1, W1]
+        b (int)
+        v (m.dtype)
+    """
+    if b <= 0:
+        return
+
+    m[:, :b] = v
+    m[:, :, :b] = v
+    m[:, :, :, :b] = v
+    m[:, :, :, :, :b] = v
+    m[:, -b:] = v
+    m[:, :, -b:] = v
+    m[:, :, :, -b:] = v
+    m[:, :, :, :, -b:] = v
+
+
+def mask_border_with_padding(m, bd, v, p_m0, p_m1):
+    if bd <= 0:
+        return
+
+    m[:, :bd] = v
+    m[:, :, :bd] = v
+    m[:, :, :, :bd] = v
+    m[:, :, :, :, :bd] = v
+
+    h0s, w0s = p_m0.sum(1).max(-1)[0].int(), p_m0.sum(-1).max(-1)[0].int()
+    h1s, w1s = p_m1.sum(1).max(-1)[0].int(), p_m1.sum(-1).max(-1)[0].int()
+    for b_idx, (h0, w0, h1, w1) in enumerate(zip(h0s, w0s, h1s, w1s)):
+        m[b_idx, h0 - bd:] = v
+        m[b_idx, :, w0 - bd:] = v
+        m[b_idx, :, :, h1 - bd:] = v
+        m[b_idx, :, :, :, w1 - bd:] = v
+
+
+def compute_max_candidates(p_m0, p_m1):
+    """Compute the max candidates of all pairs within a batch
+    
+    Args:
+        p_m0, p_m1 (torch.Tensor): padded masks
+    """
+    h0s, w0s = p_m0.sum(1).max(-1)[0], p_m0.sum(-1).max(-1)[0]
+    h1s, w1s = p_m1.sum(1).max(-1)[0], p_m1.sum(-1).max(-1)[0]
+    max_cand = torch.sum(
+        torch.min(torch.stack([h0s * w0s, h1s * w1s], -1), -1)[0])
+    return max_cand
+
+
+class CoarseMatching(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        # general config
+        self.thr = config['thr']
+        self.border_rm = config['border_rm']
+        # -- # for trainig fine-level LoFTR
+        self.train_coarse_percent = config['train_coarse_percent']
+        self.train_pad_num_gt_min = config['train_pad_num_gt_min']
+
+        # we provide 2 options for differentiable matching
+        self.match_type = config['match_type']
+        if self.match_type == 'dual_softmax':
+            self.temperature = config['dsmax_temperature']
+        elif self.match_type == 'sinkhorn':
+            try:
+                from .superglue import log_optimal_transport
+            except ImportError:
+                raise ImportError("download superglue.py first!")
+            self.log_optimal_transport = log_optimal_transport
+            self.bin_score = nn.Parameter(
+                torch.tensor(config['skh_init_bin_score'], requires_grad=True))
+            self.skh_iters = config['skh_iters']
+            self.skh_prefilter = config['skh_prefilter']
+        else:
+            raise NotImplementedError()
+
+    def forward(self, feat_c0, feat_c1, data, mask_c0=None, mask_c1=None):
+        """
+        Args:
+            feat0 (torch.Tensor): [N, L, C]
+            feat1 (torch.Tensor): [N, S, C]
+            data (dict)
+            mask_c0 (torch.Tensor): [N, L] (optional)
+            mask_c1 (torch.Tensor): [N, S] (optional)
+        Update:
+            data (dict): {
+                'b_ids' (torch.Tensor): [M'],
+                'i_ids' (torch.Tensor): [M'],
+                'j_ids' (torch.Tensor): [M'],
+                'gt_mask' (torch.Tensor): [M'],
+                'mkpts0_c' (torch.Tensor): [M, 2],
+                'mkpts1_c' (torch.Tensor): [M, 2],
+                'mconf' (torch.Tensor): [M]}
+            NOTE: M' != M during training.
+        """
+        N, L, S, C = feat_c0.size(0), feat_c0.size(1), feat_c1.size(1), feat_c0.size(2)
+
+        # normalize
+        feat_c0, feat_c1 = map(lambda feat: feat / feat.shape[-1]**.5,
+                               [feat_c0, feat_c1])
+
+        if self.match_type == 'dual_softmax':
+            sim_matrix = torch.einsum("nlc,nsc->nls", feat_c0,
+                                      feat_c1) / self.temperature
+            if mask_c0 is not None:
+                sim_matrix.masked_fill_(
+                    ~(mask_c0[..., None] * mask_c1[:, None]).bool(),
+                    -INF)
+            conf_matrix = F.softmax(sim_matrix, 1) * F.softmax(sim_matrix, 2)
+
+        elif self.match_type == 'sinkhorn':
+            # sinkhorn, dustbin included
+            sim_matrix = torch.einsum("nlc,nsc->nls", feat_c0, feat_c1)
+            if mask_c0 is not None:
+                sim_matrix[:, :L, :S].masked_fill_(
+                    ~(mask_c0[..., None] * mask_c1[:, None]).bool(),
+                    -INF)
+
+            # build uniform prior & use sinkhorn
+            log_assign_matrix = self.log_optimal_transport(
+                sim_matrix, self.bin_score, self.skh_iters)
+            assign_matrix = log_assign_matrix.exp()
+            conf_matrix = assign_matrix[:, :-1, :-1]
+
+            # filter prediction with dustbin score (only in evaluation mode)
+            if not self.training and self.skh_prefilter:
+                filter0 = (assign_matrix.max(dim=2)[1] == S)[:, :-1]  # [N, L]
+                filter1 = (assign_matrix.max(dim=1)[1] == L)[:, :-1]  # [N, S]
+                conf_matrix[filter0[..., None].repeat(1, 1, S)] = 0
+                conf_matrix[filter1[:, None].repeat(1, L, 1)] = 0
+
+            if self.config['sparse_spvs']:
+                data.update({'conf_matrix_with_bin': assign_matrix.clone()})
+
+        data.update({'conf_matrix': conf_matrix})
+
+        # predict coarse matches from conf_matrix
+        data.update(**self.get_coarse_match(conf_matrix, data))
+
+    @torch.no_grad()
+    def get_coarse_match(self, conf_matrix, data):
+        """
+        Args:
+            conf_matrix (torch.Tensor): [N, L, S]
+            data (dict): with keys ['hw0_i', 'hw1_i', 'hw0_c', 'hw1_c']
+        Returns:
+            coarse_matches (dict): {
+                'b_ids' (torch.Tensor): [M'],
+                'i_ids' (torch.Tensor): [M'],
+                'j_ids' (torch.Tensor): [M'],
+                'gt_mask' (torch.Tensor): [M'],
+                'm_bids' (torch.Tensor): [M],
+                'mkpts0_c' (torch.Tensor): [M, 2],
+                'mkpts1_c' (torch.Tensor): [M, 2],
+                'mconf' (torch.Tensor): [M]}
+        """
+        axes_lengths = {
+            'h0c': data['hw0_c'][0],
+            'w0c': data['hw0_c'][1],
+            'h1c': data['hw1_c'][0],
+            'w1c': data['hw1_c'][1]
+        }
+        _device = conf_matrix.device
+        # 1. confidence thresholding
+        mask = conf_matrix > self.thr
+        mask = rearrange(mask, 'b (h0c w0c) (h1c w1c) -> b h0c w0c h1c w1c',
+                         **axes_lengths)
+        if 'mask0' not in data:
+            mask_border(mask, self.border_rm, False)
+        else:
+            mask_border_with_padding(mask, self.border_rm, False,
+                                     data['mask0'], data['mask1'])
+        mask = rearrange(mask, 'b h0c w0c h1c w1c -> b (h0c w0c) (h1c w1c)',
+                         **axes_lengths)
+
+        # 2. mutual nearest
+        mask = mask \
+            * (conf_matrix == conf_matrix.max(dim=2, keepdim=True)[0]) \
+            * (conf_matrix == conf_matrix.max(dim=1, keepdim=True)[0])
+
+        # 3. find all valid coarse matches
+        # this only works when at most one `True` in each row
+        mask_v, all_j_ids = mask.max(dim=2)
+        b_ids, i_ids = torch.where(mask_v)
+        j_ids = all_j_ids[b_ids, i_ids]
+        mconf = conf_matrix[b_ids, i_ids, j_ids]
+
+        # 4. Random sampling of training samples for fine-level LoFTR
+        # (optional) pad samples with gt coarse-level matches
+        if self.training:
+            # NOTE:
+            # The sampling is performed across all pairs in a batch without manually balancing
+            # #samples for fine-level increases w.r.t. batch_size
+            if 'mask0' not in data:
+                num_candidates_max = mask.size(0) * max(
+                    mask.size(1), mask.size(2))
+            else:
+                num_candidates_max = compute_max_candidates(
+                    data['mask0'], data['mask1'])
+            num_matches_train = int(num_candidates_max *
+                                    self.train_coarse_percent)
+            num_matches_pred = len(b_ids)
+            assert self.train_pad_num_gt_min < num_matches_train, "min-num-gt-pad should be less than num-train-matches"
+
+            # pred_indices is to select from prediction
+            if num_matches_pred <= num_matches_train - self.train_pad_num_gt_min:
+                pred_indices = torch.arange(num_matches_pred, device=_device)
+            else:
+                pred_indices = torch.randint(
+                    num_matches_pred,
+                    (num_matches_train - self.train_pad_num_gt_min, ),
+                    device=_device)
+
+            # gt_pad_indices is to select from gt padding. e.g. max(3787-4800, 200)
+            gt_pad_indices = torch.randint(
+                    len(data['spv_b_ids']),
+                    (max(num_matches_train - num_matches_pred,
+                        self.train_pad_num_gt_min), ),
+                    device=_device)
+            mconf_gt = torch.zeros(len(data['spv_b_ids']), device=_device)  # set conf of gt paddings to all zero
+
+            b_ids, i_ids, j_ids, mconf = map(
+                lambda x, y: torch.cat([x[pred_indices], y[gt_pad_indices]],
+                                       dim=0),
+                *zip([b_ids, data['spv_b_ids']], [i_ids, data['spv_i_ids']],
+                     [j_ids, data['spv_j_ids']], [mconf, mconf_gt]))
+
+        # These matches select patches that feed into fine-level network
+        coarse_matches = {'b_ids': b_ids, 'i_ids': i_ids, 'j_ids': j_ids}
+
+        # 4. Update with matches in original image resolution
+        scale = data['hw0_i'][0] / data['hw0_c'][0]
+        scale0 = scale * data['scale0'][b_ids] if 'scale0' in data else scale
+        scale1 = scale * data['scale1'][b_ids] if 'scale1' in data else scale
+        mkpts0_c = torch.stack(
+            [i_ids % data['hw0_c'][1], i_ids // data['hw0_c'][1]],
+            dim=1) * scale0
+        mkpts1_c = torch.stack(
+            [j_ids % data['hw1_c'][1], j_ids // data['hw1_c'][1]],
+            dim=1) * scale1
+
+        # These matches is the current prediction (for visualization)
+        coarse_matches.update({
+            'gt_mask': mconf == 0,
+            'm_bids': b_ids[mconf != 0],  # mconf == 0 => gt matches
+            'mkpts0_c': mkpts0_c[mconf != 0],
+            'mkpts1_c': mkpts1_c[mconf != 0],
+            'mconf': mconf[mconf != 0]
+        })
+
+        return coarse_matches

--- a/plugins/pytorch/minima_loftr/utils/fine_matching.py
+++ b/plugins/pytorch/minima_loftr/utils/fine_matching.py
@@ -1,0 +1,100 @@
+import math
+import torch
+import torch.nn as nn
+
+
+def create_meshgrid(height, width, normalized_coordinates, device):
+    """Local replacement for kornia.utils.grid.create_meshgrid.
+
+    Returns a (1, H, W, 2) grid with last dim (x, y); normalized to [-1, 1]
+    when normalized_coordinates is True (align_corners convention).
+    """
+    if normalized_coordinates:
+        xs = torch.linspace(-1.0, 1.0, width, device=device)
+        ys = torch.linspace(-1.0, 1.0, height, device=device)
+    else:
+        xs = torch.arange(width, device=device, dtype=torch.float32)
+        ys = torch.arange(height, device=device, dtype=torch.float32)
+    grid_y, grid_x = torch.meshgrid(ys, xs, indexing='ij')
+    return torch.stack((grid_x, grid_y), dim=-1).unsqueeze(0)
+
+
+def spatial_expectation2d(heatmap, normalized_coordinates=True):
+    """Local replacement for kornia.geometry.subpix.dsnt.spatial_expectation2d.
+
+    heatmap: (B, N, H, W) spatial probability maps (already softmaxed).
+    Returns (B, N, 2) expected (x, y) coordinates.
+    """
+    b, n, h, w = heatmap.shape
+    grid = create_meshgrid(h, w, normalized_coordinates, heatmap.device)
+    grid = grid.reshape(1, 1, h * w, 2)
+    probs = heatmap.reshape(b, n, h * w, 1)
+    return torch.sum(probs * grid, dim=2)
+
+
+class FineMatching(nn.Module):
+    """FineMatching with s2d paradigm"""
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, feat_f0, feat_f1, data):
+        """
+        Args:
+            feat0 (torch.Tensor): [M, WW, C]
+            feat1 (torch.Tensor): [M, WW, C]
+            data (dict)
+        Update:
+            data (dict):{
+                'expec_f' (torch.Tensor): [M, 3],
+                'mkpts0_f' (torch.Tensor): [M, 2],
+                'mkpts1_f' (torch.Tensor): [M, 2]}
+        """
+        M, WW, C = feat_f0.shape
+        W = int(math.sqrt(WW))
+        scale = data['hw0_i'][0] / data['hw0_f'][0]
+        self.M, self.W, self.WW, self.C, self.scale = M, W, WW, C, scale
+
+        # corner case: if no coarse matches found
+        if M == 0:
+            assert self.training == False, "M is always >0, when training, see coarse_matching.py"
+            # logger.warning('No matches found in coarse-level.')
+            data.update({
+                'expec_f': torch.empty(0, 3, device=feat_f0.device),
+                'mkpts0_f': data['mkpts0_c'],
+                'mkpts1_f': data['mkpts1_c'],
+            })
+            return
+
+        feat_f0_picked = feat_f0_picked = feat_f0[:, WW//2, :]
+        sim_matrix = torch.einsum('mc,mrc->mr', feat_f0_picked, feat_f1)
+        softmax_temp = 1. / C**.5
+        heatmap = torch.softmax(softmax_temp * sim_matrix, dim=1).view(-1, W, W)
+
+        # compute coordinates from heatmap
+        coords_normalized = spatial_expectation2d(heatmap[None], True)[0]  # [M, 2]
+        grid_normalized = create_meshgrid(W, W, True, heatmap.device).reshape(1, -1, 2)  # [1, WW, 2]
+
+        # compute std over <x, y>
+        var = torch.sum(grid_normalized**2 * heatmap.view(-1, WW, 1), dim=1) - coords_normalized**2  # [M, 2]
+        std = torch.sum(torch.sqrt(torch.clamp(var, min=1e-10)), -1)  # [M]  clamp needed for numerical stability
+        
+        # for fine-level supervision
+        data.update({'expec_f': torch.cat([coords_normalized, std.unsqueeze(1)], -1)})
+
+        # compute absolute kpt coords
+        self.get_fine_match(coords_normalized, data)
+
+    @torch.no_grad()
+    def get_fine_match(self, coords_normed, data):
+        W, WW, C, scale = self.W, self.WW, self.C, self.scale
+
+        # mkpts0_f and mkpts1_f
+        mkpts0_f = data['mkpts0_c']
+        scale1 = scale * data['scale1'][data['b_ids']] if 'scale0' in data else scale
+        mkpts1_f = data['mkpts1_c'] + (coords_normed * (W // 2) * scale1)[:len(data['mconf'])]
+
+        data.update({
+            "mkpts0_f": mkpts0_f,
+            "mkpts1_f": mkpts1_f
+        })

--- a/plugins/pytorch/minima_loftr/utils/position_encoding.py
+++ b/plugins/pytorch/minima_loftr/utils/position_encoding.py
@@ -1,0 +1,42 @@
+import math
+import torch
+from torch import nn
+
+
+class PositionEncodingSine(nn.Module):
+    """
+    This is a sinusoidal position encoding that generalized to 2-dimensional images
+    """
+
+    def __init__(self, d_model, max_shape=(256, 256), temp_bug_fix=True):
+        """
+        Args:
+            max_shape (tuple): for 1/8 featmap, the max length of 256 corresponds to 2048 pixels
+            temp_bug_fix (bool): As noted in this [issue](https://github.com/zju3dv/LoFTR/issues/41),
+                the original implementation of LoFTR includes a bug in the pos-enc impl, which has little impact
+                on the final performance. For now, we keep both impls for backward compatability.
+                We will remove the buggy impl after re-training all variants of our released models.
+        """
+        super().__init__()
+
+        pe = torch.zeros((d_model, *max_shape))
+        y_position = torch.ones(max_shape).cumsum(0).float().unsqueeze(0)
+        x_position = torch.ones(max_shape).cumsum(1).float().unsqueeze(0)
+        if temp_bug_fix:
+            div_term = torch.exp(torch.arange(0, d_model//2, 2).float() * (-math.log(10000.0) / (d_model//2)))
+        else:  # a buggy implementation (for backward compatability only)
+            div_term = torch.exp(torch.arange(0, d_model//2, 2).float() * (-math.log(10000.0) / d_model//2))
+        div_term = div_term[:, None, None]  # [C//4, 1, 1]
+        pe[0::4, :, :] = torch.sin(x_position * div_term)
+        pe[1::4, :, :] = torch.cos(x_position * div_term)
+        pe[2::4, :, :] = torch.sin(y_position * div_term)
+        pe[3::4, :, :] = torch.cos(y_position * div_term)
+
+        self.register_buffer('pe', pe.unsqueeze(0), persistent=False)  # [1, C, H, W]
+
+    def forward(self, x):
+        """
+        Args:
+            x: [N, C, H, W]
+        """
+        return x + self.pe[:, :, :x.size(2), :x.size(3)]


### PR DESCRIPTION
# Auto Align via LoFTR

**What:** A Python inference backend that computes the homography aligning two
camera images of the same scene — usually different modalities (EO/RGB ↔ thermal
IR / UV) — using the vendored **MINIMA-LoFTR** deep matcher. It returns a 3×3
homography plus the best ~20 inlier correspondences, or an actionable failure code.

**Why:** EO and IR look nothing alike to classic detectors (SIFT/ORB), so
aligning them meant tedious manual point-picking, especially in the KAMERA system
with its multiple modalities (EO/IR/UV). MINIMA-LoFTR is fine-tuned for
cross-modality matching. The correspondences drop into the existing calibration
flow as ordinary point pairs, and unmatchable scenes fail loud instead of
producing a bad warp. These point pairs can then be directly fed into DIVE
for multicam datasets to link pan and zoom for easy viewing.

**Where:**
- `plugins/pytorch/minima_loftr/` — vendored matcher (inference only)
- `plugins/core/interactive_alignment.py` — matching, RANSAC/refit, quality gate
- `plugins/core/interactive_service.py` — hosts it alongside segmentation +
  stereo in one process; routes `auto_align` / `get_alignment_status`
- GPU memory is freed **on demand** — the matcher is unloaded (model
  dropped, CUDA/MPS cache emptied) just before a competing segmentation/stereo
  model runs. It reloads lazily on the next `auto_align`.

## Verification

9/9 test EO/IR image pairs were successful from a calibration flight - high inlier count with <2px reprojection error. Only took a few seconds on M1 MAC.