### PR TITLE
sea-lion: loop-closure evaluation tooling

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -26,6 +26,9 @@ set( PYTHON_SCRIPTS
 if( VIAME_ENABLE_OPENCV )
   set( PYTHON_SCRIPTS
     ${PYTHON_SCRIPTS}
+    analyze_match_failures.py
+    build_pixel_mosaic.py
+    evaluate_loop_closures.py
     calibrate.py
     depth.py
     disparity.py

--- a/tools/analyze_match_failures.py
+++ b/tools/analyze_match_failures.py
@@ -1,0 +1,382 @@
+# This file is part of VIAME, and is distributed under an OSI-approved #
+# BSD 3-Clause License. See either the root top-level LICENSE file or  #
+# https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.    #
+"""Catalogue registration/matching FAILURE CASES for a survey site.
+
+Aerial sea-lion survey imagery is dominated by two terrain types that break
+feature matching:
+
+  * open ocean / seaweed water - no stable features; SIFT locks onto waves,
+    glint and foam that move between frames, so a "successful" match is
+    meaningless.
+  * tussock grass / vegetated island interior ("all_land") - highly repetitive
+    self-similar texture, so SIFT aliases onto the WRONG patch of grass and
+    produces a confident but geometrically wrong match.
+
+Both failures look like a successful registration from inside the pipeline.
+This tool exposes them by cross-checking every match the pipeline CLAIMED
+against the flight-log GPS, which is independent of the imagery:
+
+    if the images say "these two frames see the same ground"
+    but the GPS says the aircraft was 400 m away
+    -> the match is false, and we can name the exact frame it matched against.
+
+Inputs are a site folder plus the ``revisits.csv`` that
+``detect_prior_coverage.py`` wrote for it. Phase 1 (metadata only, ~free)
+flags the false/missed matches. Phase 2 (``--visualize``) re-runs SIFT on the
+flagged pairs to record inlier counts and render side-by-side match images, so
+the failure can be eyeballed later.
+
+Usage::
+
+    analyze_match_failures.py SITE --flight-logs DIR --revisits-csv OUT/revisits.csv \\
+        --output OUT/failures [--visualize]
+"""
+
+import argparse
+import csv
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import numpy as np
+
+from viame.core import survey_metadata as smd
+
+# SVM background-classifier labels -> coarse terrain bucket. On these islands
+# 'all_land' is predominantly tussock grass / low vegetation, which is the
+# repetitive texture that causes aliased matches.
+TERRAIN = {
+    'open_water': 'ocean',
+    'seaweed_water': 'ocean',
+    'cloudy': 'cloud',
+    'coastal': 'coastal',
+    'all_land': 'grass_land',
+}
+
+# A claimed match between frames whose GPS positions differ by more than this
+# cannot be real: image footprints are ~105 m across at survey altitude, so
+# frames >150 m apart share no ground at all.
+FOOTPRINT_M = 105.0
+
+
+def _terrain(label):
+    return TERRAIN.get(label, 'unknown')
+
+
+def _pair_terrain(ta, tb):
+    if ta == tb:
+        return ta
+    if 'ocean' in (ta, tb) and 'coastal' in (ta, tb):
+        return 'coastal'
+    return f'{ta}+{tb}'
+
+
+def load_site_geo(site_folder, flight_logs, xcam_offset_frac=0.9):
+    """Per-image ground FOOTPRINT (not aircraft position) in a shared ENU frame.
+
+    The rig's PORT/STAR cameras are canted across-track, so their footprints sit
+    ~0.9 footprint-widths off the aircraft track. Testing shared ground with raw
+    aircraft positions would both invent false failures (PORT/STAR pairs whose
+    footprints really do overlap despite the aircraft being far apart) and hide
+    real ones (PORT vs STAR at the same trigger: aircraft distance 0, but ~190 m
+    between footprints).
+    """
+    return smd.build_footprints(site_folder, flight_logs=flight_logs,
+                                xcam_offset_frac=xcam_offset_frac,
+                                read_exif=False, verbose=False)
+
+
+def _footprint_overlap(qa, qb):
+    """Fraction of the smaller footprint covered by the intersection (0 = no
+    shared ground)."""
+    import cv2
+    a = np.array(qa, dtype=np.float32)
+    b = np.array(qb, dtype=np.float32)
+    inter, _ = cv2.intersectConvexConvex(a, b)
+    if not inter or inter <= 0:
+        return 0.0
+    aa, ab = cv2.contourArea(a), cv2.contourArea(b)
+    return float(inter / max(min(aa, ab), 1e-6))
+
+
+def classify_terrain(site_folder, rels, method='auto'):
+    """SVM/SIFT water-land label per image; {} if the classifier is unavailable."""
+    try:
+        from viame.opencv import registration_utils as ru
+        ru.import_dependencies()
+        return ru.classify_images_fast(site_folder, rels, method=method)
+    except Exception as e:
+        print(f'    terrain classification unavailable ({e})')
+        return {}
+
+
+def load_coverage_claims(coverage_csv, geo):
+    """Claimed shared-ground pairs from a prior_coverage.csv.
+
+    Each row is one previously-seen region of an image, tagged with the source
+    frame that saw it (``(note) src=CAM#FRAME``) and a class suffix
+    (_sequential / _cross_camera / _revisit). Yields deduped
+    (image, source_image, kind) triples. This covers the whole registration
+    chain -- notably the SEQUENTIAL matches over open water, which are where a
+    mosaic actually tears -- rather than only the revisit events.
+    """
+    if not coverage_csv or not os.path.isfile(coverage_csv):
+        return []
+    # (cam, frame) -> rel path, to resolve the src=CAM#FRAME tag.
+    by_cam_frame = {}
+    for rel, g in geo.items():
+        by_cam_frame[(str(g.get('cam')), str(g.get('frame')))] = rel
+
+    claims, seen = [], set()
+    with open(coverage_csv) as f:
+        for line in f:
+            if line.startswith('#') or ',' not in line:
+                continue
+            parts = line.rstrip('\n').split(',')
+            if len(parts) < 10:
+                continue
+            rel = parts[1]
+            cls = parts[9]
+            if 'prior_coverage_' not in cls:
+                continue
+            kind = cls.split('prior_coverage_')[-1]
+            m = None
+            for p in parts:
+                if 'src=' in p:
+                    m = p.split('src=')[-1].strip()
+                    break
+            if not m or '#' not in m:
+                continue
+            cam, frame = m.split('#', 1)
+            src_rel = by_cam_frame.get((cam, frame))
+            if not src_rel or src_rel == rel:
+                continue
+            key = (rel, src_rel, kind)
+            if key in seen:
+                continue
+            seen.add(key)
+            claims.append(key)
+    return claims
+
+
+def analyze(site_folder, flight_logs, revisits_csv, water_method='auto',
+            min_overlap=0.0, coverage_csv=None, xcam_offset_frac=0.9):
+    """Cross-check every match the pipeline claimed against flight-log GPS.
+
+    Checks both the revisit events (revisits.csv) and, when given, every
+    claimed shared-ground region of the registration chain
+    (prior_coverage.csv: sequential / cross_camera / revisit).
+
+    A claim is false when the two frames' GPS-derived ground footprints do not
+    overlap at all: the images assert they see the same ground, the flight log
+    says they cannot.
+    """
+    geo, cams = load_site_geo(site_folder, flight_logs, xcam_offset_frac)
+    if not geo:
+        print('    no GPS fixes for this site; cannot cross-check matches')
+        return [], {}
+
+    # (image, source_image, kind, confirmed, overlap) claims from both sources.
+    claims = []
+    if os.path.isfile(revisits_csv):
+        for r in csv.DictReader(open(revisits_csv)):
+            claims.append((r['image'], r['source_image'], 'revisit',
+                           str(r.get('confirmed', '')).strip().lower()
+                           in ('yes', 'true', '1'),
+                           r.get('overlap_frac', '')))
+    for rel, src, kind in load_coverage_claims(coverage_csv, geo):
+        claims.append((rel, src, kind, None, ''))
+    if not claims:
+        print('    no claimed matches found to check')
+        return [], {}
+
+    # Terrain only for frames actually involved in a claim.
+    involved = sorted({c[0] for c in claims} | {c[1] for c in claims})
+    involved = [r for r in involved if os.path.isfile(os.path.join(site_folder, r))]
+    water = classify_terrain(site_folder, involved, water_method)
+
+    site_tag = os.path.basename(os.path.normpath(site_folder))
+    failures = []
+    stats = {'claims': 0, 'false': 0, 'confirmed_false': 0, 'ok': 0, 'no_gps': 0}
+    seen = set()
+
+    for a, b, kind, confirmed, overlap in claims:
+        if (a, b, kind) in seen:
+            continue
+        seen.add((a, b, kind))
+        stats['claims'] += 1
+        ga, gb = geo.get(a), geo.get(b)
+        if not ga or not gb:
+            stats['no_gps'] += 1
+            continue
+        # Compare where the CAMERAS actually looked (footprints), not where the
+        # aircraft was: the PORT/STAR cant makes those two very different.
+        fov = _footprint_overlap(ga['quad'], gb['quad'])
+        d = float(np.hypot(ga['center'][0] - gb['center'][0],
+                           ga['center'][1] - gb['center'][1]))
+        la = (water.get(a) or {}).get('label', 'unknown')
+        lb = (water.get(b) or {}).get('label', 'unknown')
+        ta, tb = _terrain(la), _terrain(lb)
+
+        if fov > min_overlap:
+            stats['ok'] += 1
+            continue
+
+        # Footprints share no ground, yet the pipeline claimed they do -> false
+        # match. `confirmed` means SIFT actively vouched for it (the worse case:
+        # a genuine wrong feature match, not just grid bookkeeping).
+        stats['false'] += 1
+        if confirmed:
+            stats['confirmed_false'] += 1
+        mode = f'false_{kind}'
+        if confirmed:
+            mode += '_sift_confirmed'
+        failures.append({
+            'site': site_tag,
+            'camera': (ga.get('cam') or ''),
+            'frame': (ga.get('frame') if ga else ''),
+            'image': a,
+            'matched_against_image': b,
+            'matched_against_frame': (gb.get('frame') if gb else ''),
+            'match_kind': kind,
+            'terrain': _pair_terrain(ta, tb),
+            'class_image': la,
+            'class_matched_against': lb,
+            'footprint_gap_m': f'{d:.1f}',
+            'overlap_frac_claimed': overlap,
+            'sift_confirmed': ('yes' if confirmed else
+                               ('no' if confirmed is False else 'n/a')),
+            'failure_mode': mode,
+            'note': (f'GPS footprints disjoint (centres {d:.0f} m apart, '
+                     f'~{FOOTPRINT_M:.0f} m footprint): frames share no ground'),
+        })
+    failures.sort(key=lambda f: -float(f['footprint_gap_m']))
+    return failures, stats
+
+
+def write_failures_csv(path, failures):
+    cols = ['site', 'camera', 'frame', 'image', 'matched_against_image',
+            'matched_against_frame', 'match_kind', 'terrain', 'class_image',
+            'class_matched_against', 'footprint_gap_m', 'overlap_frac_claimed',
+            'sift_confirmed', 'failure_mode', 'note']
+    with open(path, 'w', newline='') as f:
+        w = csv.DictWriter(f, fieldnames=cols)
+        w.writeheader()
+        for r in failures:
+            w.writerow(r)
+
+
+def visualize_failures(site_folder, failures, out_dir, limit=12, scale=0.25):
+    """Render side-by-side image pairs with SIFT matches drawn, so a human can
+    see WHY the match was wrong (waves/glint on ocean, aliased grass texture)."""
+    try:
+        import cv2
+    except ImportError:
+        return 0
+    os.makedirs(out_dir, exist_ok=True)
+    n = 0
+    for fr in failures[:limit]:
+        pa = os.path.join(site_folder, fr['image'])
+        pb = os.path.join(site_folder, fr['matched_against_image'])
+        ia, ib = cv2.imread(pa), cv2.imread(pb)
+        if ia is None or ib is None:
+            continue
+        ia = cv2.resize(ia, None, fx=scale, fy=scale)
+        ib = cv2.resize(ib, None, fx=scale, fy=scale)
+        ga = cv2.cvtColor(ia, cv2.COLOR_BGR2GRAY)
+        gb = cv2.cvtColor(ib, cv2.COLOR_BGR2GRAY)
+        sift = cv2.SIFT_create(nfeatures=4000)
+        ka, da = sift.detectAndCompute(ga, None)
+        kb, db = sift.detectAndCompute(gb, None)
+        if da is None or db is None:
+            continue
+        good = []
+        for m_n in cv2.BFMatcher().knnMatch(da, db, k=2):
+            if len(m_n) == 2 and m_n[0].distance < 0.8 * m_n[1].distance:
+                good.append(m_n[0])
+        vis = cv2.drawMatches(ia, ka, ib, kb, good[:60], None,
+                              flags=cv2.DrawMatchesFlags_NOT_DRAW_SINGLE_POINTS)
+        hdr = (f"{fr['terrain']}  footprints {fr['footprint_gap_m']}m apart  "
+               f"sift_confirmed={fr['sift_confirmed']}  ({len(good)} raw matches)")
+        cv2.putText(vis, hdr, (10, 22), cv2.FONT_HERSHEY_SIMPLEX, 0.6,
+                    (0, 0, 255), 2, cv2.LINE_AA)
+        cv2.putText(vis, f"{os.path.basename(fr['image'])}  vs  "
+                         f"{os.path.basename(fr['matched_against_image'])}",
+                    (10, 46), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 255), 1,
+                    cv2.LINE_AA)
+        name = f"{fr['terrain']}_{os.path.splitext(os.path.basename(fr['image']))[0]}.jpg"
+        cv2.imwrite(os.path.join(out_dir, name), vis)
+        n += 1
+    return n
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('site')
+    ap.add_argument('--flight-logs', default=None)
+    ap.add_argument('--revisits-csv', required=True)
+    ap.add_argument('--coverage-csv', default=None,
+                    help='prior_coverage.csv from the same run: also checks the '
+                         'sequential / cross-camera chain matches, not just revisits')
+    ap.add_argument('--output', required=True, help='Output directory')
+    ap.add_argument('--water-method', choices=['auto', 'svm', 'sift'], default='auto')
+    ap.add_argument('--min-overlap', type=float, default=0.0,
+                    help='Claimed matches whose GPS footprints overlap by no '
+                         'more than this fraction are false (default 0 = '
+                         'footprints must be strictly disjoint to flag)')
+    ap.add_argument('--xcam-offset-frac', type=float, default=0.9,
+                    help='Across-track cant of PORT/STAR footprints as a '
+                         'fraction of footprint width (match '
+                         'detect_prior_coverage.py --xcam-offset-frac)')
+    ap.add_argument('--visualize', action='store_true',
+                    help='Render side-by-side SIFT-match images for flagged pairs')
+    ap.add_argument('--vis-limit', type=int, default=12)
+    args = ap.parse_args()
+
+    os.makedirs(args.output, exist_ok=True)
+    site_tag = os.path.basename(os.path.normpath(args.site))
+    print(f'=== {site_tag}: match failure analysis ===')
+
+    failures, stats = analyze(args.site, args.flight_logs, args.revisits_csv,
+                              args.water_method, args.min_overlap,
+                              coverage_csv=args.coverage_csv,
+                              xcam_offset_frac=args.xcam_offset_frac)
+    csv_path = os.path.join(args.output, 'match_failures.csv')
+    write_failures_csv(csv_path, failures)
+
+    print(f"  claimed matches checked : {stats.get('claims', 0)}")
+    print(f"  footprint-consistent(OK): {stats.get('ok', 0)}")
+    print(f"  FALSE matches           : {stats.get('false', 0)}"
+          f"  (of which SIFT-confirmed: {stats.get('confirmed_false', 0)})")
+    if stats.get('no_gps'):
+        print(f"  skipped (no GPS)        : {stats['no_gps']}")
+
+    if failures:
+        from collections import Counter
+        by_terrain = Counter(f['terrain'] for f in failures)
+        by_kind = Counter(f['match_kind'] for f in failures)
+        print('  false matches by terrain:')
+        for t, c in by_terrain.most_common():
+            print(f'    {t:20s} {c}')
+        print('  false matches by match kind:')
+        for k, c in by_kind.most_common():
+            print(f'    {k:20s} {c}')
+        worst = failures[0]
+        print(f"  worst: {os.path.basename(worst['image'])} matched against "
+              f"{os.path.basename(worst['matched_against_image'])} "
+              f"(footprints {worst['footprint_gap_m']} m apart, "
+              f"{worst['terrain']})")
+        print(f'  -> {csv_path}')
+        if args.visualize:
+            vdir = os.path.join(args.output, 'failure_examples')
+            n = visualize_failures(args.site, failures, vdir, args.vis_limit)
+            print(f'  rendered {n} example match images -> {vdir}')
+    else:
+        print('  no GPS-inconsistent matches found')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/analyze_match_failures.py
+++ b/tools/analyze_match_failures.py
@@ -22,7 +22,7 @@ against the flight-log GPS, which is independent of the imagery:
     -> the match is false, and we can name the exact frame it matched against.
 
 Inputs are a site folder plus the ``revisits.csv`` that
-``detect_prior_coverage.py`` wrote for it. Phase 1 (metadata only, ~free)
+``register.py`` wrote for it. Phase 1 (metadata only, ~free)
 flags the false/missed matches. Phase 2 (``--visualize``) re-runs SIFT on the
 flagged pairs to record inlier counts and render side-by-side match images, so
 the failure can be eyeballed later.
@@ -42,7 +42,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import numpy as np
 
-from viame.core import survey_metadata as smd
+import metadata as smd
 
 # SVM background-classifier labels -> coarse terrain bucket. On these islands
 # 'all_land' is predominantly tussock grass / low vegetation, which is the
@@ -330,7 +330,7 @@ def main():
     ap.add_argument('--xcam-offset-frac', type=float, default=0.9,
                     help='Across-track cant of PORT/STAR footprints as a '
                          'fraction of footprint width (match '
-                         'detect_prior_coverage.py --xcam-offset-frac)')
+                         'register.py --xcam-offset-frac)')
     ap.add_argument('--visualize', action='store_true',
                     help='Render side-by-side SIFT-match images for flagged pairs')
     ap.add_argument('--vis-limit', type=int, default=12)

--- a/tools/build_pixel_mosaic.py
+++ b/tools/build_pixel_mosaic.py
@@ -1,0 +1,215 @@
+# This file is part of VIAME, and is distributed under an OSI-approved #
+# BSD 3-Clause License. See either the root top-level LICENSE file or  #
+# https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.    #
+"""Build a pixel-stitched mosaic for a survey site without the compiled
+KWIVER stabilization pipeline (``many_image_stabilizer`` / ``kw_write_homography``).
+
+Reuses the same registration engine as ``detect_prior_coverage.py``
+(``viame.opencv.registration_utils``) to build a per-camera homography chain,
+GPS-anchors/fills frames that failed direct registration, then runs a
+pose-graph optimization pass using ``detect_loop_edges`` /
+``optimize_pose_graph`` so temporally-distant revisits (loop closures) pull
+the chain back into alignment instead of drifting. The resulting per-camera
+homographies are written in ``create_mosaic.py``'s file format and stitched
+with it.
+
+Usage::
+
+    build_pixel_mosaic.py SITE_FOLDER --flight-logs DIR --output OUT_DIR
+"""
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import numpy as np
+
+# Source JPEGs in this dataset are slightly truncated (trailing bytes missing,
+# harmless -- OpenCV loads them with just a warning) but PIL/skimage, which
+# create_mosaic.py reads images with, raises OSError on them by default.
+from PIL import ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
+
+from viame.core import survey_metadata as smd
+import create_mosaic as cm
+from viame.opencv import registration_utils as ru
+from viame.opencv.registration_utils import (
+    compute_homography_pair,
+    detect_loop_edges,
+    optimize_pose_graph,
+)
+
+def _find_anchor(chain):
+    """Recover the anchor index _compute_camera_chain seeded with identity."""
+    return min(chain.keys(), key=lambda k: np.linalg.norm(chain[k] - np.eye(3)))
+
+
+def build_camera_chain(site_folder, cam, rels, water_info, args):
+    """Return (final_chain: index -> H_to_anchor, anchor_idx, n_loop_edges, pairwise_H)."""
+    # Affine (not full homography) chains: perspective terms compound over
+    # 100+-frame chains and drive the far end's scale toward zero (observed:
+    # median frame scale 0.02 on PINNACLE ROCK), which renders as a smear.
+    # detect_prior_coverage.py uses affine for the same reason.
+    ch, pw = ru._compute_camera_chain(
+        site_folder, rels, label=str(cam), water_info=water_info,
+        match_ratio=args.match_ratio, min_inliers=args.min_inliers,
+        scale=args.match_scale, use_affine=True, consistency_filter=True,
+    )
+    if not ch:
+        return {}, None, 0, {}
+
+    anchor_idx = _find_anchor(ch)
+
+    loop_edges = []
+    if len(ch) >= 3 and not args.no_loop_closure:
+        loop_edges = detect_loop_edges(
+            ch, site_folder, rels, min_gap=args.loop_min_gap,
+            overlap_thresh=args.loop_overlap_thresh,
+        )
+
+    seq_edges = [(i, j, H) for (i, j), H in pw.items()]
+    corrected = optimize_pose_graph(
+        ch, seq_edges, loop_edges=loop_edges, anchor=anchor_idx,
+    )
+    print(f'    {cam}: pose graph = {len(seq_edges)} sequential edges, '
+          f'{len(loop_edges)} loop-closure edges')
+    return corrected, anchor_idx, len(loop_edges), pw
+
+
+def gps_fill_gaps(chains, cams, poses_by_cam, pairwise_by_cam):
+    """Fill frames with no direct registration via GPS dead-reckoning, sharing
+    the rig's metres-to-pixels scale (same approach detect_prior_coverage.py
+    uses), so create_mosaic.py has a full-length homography file per camera.
+    No-op (frames stay dropped) for sites without flight-log/EXIF GPS.
+    """
+    if not any(poses_by_cam.get(cam) for cam in cams):
+        print('    No GPS metadata available; unregistered frames stay dropped')
+        return
+    ru._geo_anchor_cameras(chains, cams, poses_by_cam, pairwise_by_cam)
+
+
+def write_homog_file(path, chain, n):
+    """Write chain (index -> H in cv2 x,y convention) in create_mosaic.py's
+    on-disk format. create_mosaic.read_homog_file conjugates each matrix by
+    SWAP_XY on read (``swap_xy @ M_file @ swap_xy``) to get its own internal
+    Y,X-ordered representation, so the FILE itself must hold the raw cv2
+    x,y-convention matrix unmodified (conjugating twice would cancel out and
+    silently swap the mosaic's X/Y axes) -- write `chain[i]` as-is.
+
+    Frames missing from chain are dropped; caller must also drop the
+    matching lines from the image list so indices realign. `tof` is only
+    used by create_mosaic.py as a same-batch consistency tag (across ALL
+    cameras of a multi-cam mosaic), not for any computation, so a shared
+    constant (0) is used for every line.
+
+    ALL chained frames are kept, INCLUDING open water: this is a sea-lion
+    survey and animals swimming in open water must appear in the mosaic.
+    """
+    kept = [i for i in range(n) if i in chain]
+    with open(path, 'w') as f:
+        for line_no, i in enumerate(kept):
+            vals = ' '.join(f'{x:.10g}' for x in chain[i].flatten())
+            f.write(f'{vals} {line_no} 0\n')
+    return kept
+
+
+def write_image_list(path, site_folder, rels, kept_indices):
+    with open(path, 'w') as f:
+        for i in kept_indices:
+            f.write(os.path.join(site_folder, rels[i]) + '\n')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('site', help='Site folder (single camera, or rig with '
+                    'PORT/CENTER/STAR subfolders)')
+    ap.add_argument('--flight-logs', default=None,
+                    help='FMCLOG CSV or directory of them')
+    ap.add_argument('--output', required=True, help='Output directory')
+    ap.add_argument('--water-method', choices=['auto', 'svm', 'sift'], default='auto')
+    ap.add_argument('--match-ratio', type=float, default=0.80)
+    ap.add_argument('--match-scale', type=float, default=0.5)
+    ap.add_argument('--min-inliers', type=int, default=10)
+    ap.add_argument('--loop-min-gap', type=int, default=15,
+                    help='Minimum frame separation to consider a loop-closure edge')
+    ap.add_argument('--loop-overlap-thresh', type=float, default=0.15)
+    ap.add_argument('--no-loop-closure', action='store_true',
+                    help='Disable loop-closure pose-graph correction (sequential-only chain)')
+    ap.add_argument('--zoom', type=float, default=0.15,
+                    help='Mosaic output scale factor (full-res 5168x3448 source frames '
+                    'need a small value to keep memory/runtime reasonable)')
+    ap.add_argument('--step', type=int, default=1, help='Draw every Nth frame')
+    ap.add_argument('--optimize-fit', action='store_true',
+                    help='Apply create_mosaic.py distortion-minimizing global fit. '
+                    'Off by default: its 8-parameter projective search can '
+                    'degenerate on long GPS-anchored multi-camera chains.')
+    args = ap.parse_args()
+
+    ru.import_dependencies()
+    os.makedirs(args.output, exist_ok=True)
+
+    t0 = time.time()
+    site_tag = os.path.basename(os.path.normpath(args.site))
+    print(f'=== {site_tag}: building pixel mosaic ===')
+
+    records, cams = smd.build_image_records(
+        args.site, flight_logs=args.flight_logs, read_exif=True)
+    all_rels = [r for rels in cams.values() for r in rels]
+
+    print(f'  Classifying water/land ({args.water_method})...')
+    water_info = ru.classify_images_fast(args.site, all_rels, method=args.water_method)
+
+    poses_by_cam = {
+        cam: {r: records[r] for r in rels if records.get(r, {}).get('lat') is not None}
+        for cam, rels in cams.items()
+    }
+
+    chains, anchors, pairwise_by_cam = {}, {}, {}
+    total_loop_edges = 0
+    print('  Computing per-camera homography chains + loop-closure pose graph...')
+    for cam, rels in cams.items():
+        chain, anchor_idx, n_loop, pw = build_camera_chain(args.site, cam, rels, water_info, args)
+        if not chain:
+            print(f'    {cam}: no frames chained, skipping camera')
+            continue
+        chains[cam], anchors[cam], pairwise_by_cam[cam] = chain, anchor_idx, pw
+        total_loop_edges += n_loop
+
+    if not chains:
+        print('  No camera produced a usable chain; aborting.')
+        return
+
+    print('  GPS dead-reckoning fill for unregistered frames...')
+    gps_fill_gaps(chains, {c: cams[c] for c in chains}, poses_by_cam, pairwise_by_cam)
+
+    homog_and_lists = []
+    for cam, rels in cams.items():
+        if cam not in chains:
+            continue
+        chain = chains[cam]
+        anchor_idx = anchors[cam]
+        tag = cam or 'CAM'
+        hpath = os.path.join(args.output, f'{tag}_homog.txt')
+        lpath = os.path.join(args.output, f'{tag}_images.txt')
+        kept = write_homog_file(hpath, chain, len(rels))
+        write_image_list(lpath, args.site, rels, kept)
+        print(f'    {cam}: {len(kept)}/{len(rels)} frames written '
+              f'(anchor=#{anchor_idx})')
+        homog_and_lists += [hpath, lpath]
+
+    out_file = os.path.join(args.output, f'{site_tag}_mosaic.jpg')
+    print(f'  Stitching mosaic -> {out_file} (zoom={args.zoom}, step={args.step})...')
+    cm.main_multi(
+        out_file, [(h, l) for h, l in zip(homog_and_lists[0::2], homog_and_lists[1::2])],
+        optimize_fit=args.optimize_fit, zoom=args.zoom, step=args.step,
+    )
+    print(f'  Done: {total_loop_edges} loop-closure edges used, '
+          f'{time.time() - t0:.0f}s')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/build_pixel_mosaic.py
+++ b/tools/build_pixel_mosaic.py
@@ -4,13 +4,13 @@
 """Build a pixel-stitched mosaic for a survey site without the compiled
 KWIVER stabilization pipeline (``many_image_stabilizer`` / ``kw_write_homography``).
 
-Reuses the same registration engine as ``detect_prior_coverage.py``
+Reuses the same registration engine as ``register.py``
 (``viame.opencv.registration_utils``) to build a per-camera homography chain,
 GPS-anchors/fills frames that failed direct registration, then runs a
 pose-graph optimization pass using ``detect_loop_edges`` /
 ``optimize_pose_graph`` so temporally-distant revisits (loop closures) pull
 the chain back into alignment instead of drifting. The resulting per-camera
-homographies are written in ``create_mosaic.py``'s file format and stitched
+homographies are written in ``mosaic.py``'s file format and stitched
 with it.
 
 Usage::
@@ -29,12 +29,12 @@ import numpy as np
 
 # Source JPEGs in this dataset are slightly truncated (trailing bytes missing,
 # harmless -- OpenCV loads them with just a warning) but PIL/skimage, which
-# create_mosaic.py reads images with, raises OSError on them by default.
+# mosaic.py reads images with, raises OSError on them by default.
 from PIL import ImageFile
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
-from viame.core import survey_metadata as smd
-import create_mosaic as cm
+import metadata as smd
+import mosaic as cm
 from viame.opencv import registration_utils as ru
 from viame.opencv.registration_utils import (
     compute_homography_pair,
@@ -52,7 +52,7 @@ def build_camera_chain(site_folder, cam, rels, water_info, args):
     # Affine (not full homography) chains: perspective terms compound over
     # 100+-frame chains and drive the far end's scale toward zero (observed:
     # median frame scale 0.02 on PINNACLE ROCK), which renders as a smear.
-    # detect_prior_coverage.py uses affine for the same reason.
+    # register.py uses affine for the same reason.
     ch, pw = ru._compute_camera_chain(
         site_folder, rels, label=str(cam), water_info=water_info,
         match_ratio=args.match_ratio, min_inliers=args.min_inliers,
@@ -81,8 +81,8 @@ def build_camera_chain(site_folder, cam, rels, water_info, args):
 
 def gps_fill_gaps(chains, cams, poses_by_cam, pairwise_by_cam):
     """Fill frames with no direct registration via GPS dead-reckoning, sharing
-    the rig's metres-to-pixels scale (same approach detect_prior_coverage.py
-    uses), so create_mosaic.py has a full-length homography file per camera.
+    the rig's metres-to-pixels scale (same approach register.py
+    uses), so mosaic.py has a full-length homography file per camera.
     No-op (frames stay dropped) for sites without flight-log/EXIF GPS.
     """
     if not any(poses_by_cam.get(cam) for cam in cams):
@@ -92,8 +92,8 @@ def gps_fill_gaps(chains, cams, poses_by_cam, pairwise_by_cam):
 
 
 def write_homog_file(path, chain, n):
-    """Write chain (index -> H in cv2 x,y convention) in create_mosaic.py's
-    on-disk format. create_mosaic.read_homog_file conjugates each matrix by
+    """Write chain (index -> H in cv2 x,y convention) in mosaic.py's
+    on-disk format. mosaic.read_homog_file conjugates each matrix by
     SWAP_XY on read (``swap_xy @ M_file @ swap_xy``) to get its own internal
     Y,X-ordered representation, so the FILE itself must hold the raw cv2
     x,y-convention matrix unmodified (conjugating twice would cancel out and
@@ -101,7 +101,7 @@ def write_homog_file(path, chain, n):
 
     Frames missing from chain are dropped; caller must also drop the
     matching lines from the image list so indices realign. `tof` is only
-    used by create_mosaic.py as a same-batch consistency tag (across ALL
+    used by mosaic.py as a same-batch consistency tag (across ALL
     cameras of a multi-cam mosaic), not for any computation, so a shared
     constant (0) is used for every line.
 
@@ -144,7 +144,7 @@ def main():
                     'need a small value to keep memory/runtime reasonable)')
     ap.add_argument('--step', type=int, default=1, help='Draw every Nth frame')
     ap.add_argument('--optimize-fit', action='store_true',
-                    help='Apply create_mosaic.py distortion-minimizing global fit. '
+                    help='Apply mosaic.py distortion-minimizing global fit. '
                     'Off by default: its 8-parameter projective search can '
                     'degenerate on long GPS-anchored multi-camera chains.')
     args = ap.parse_args()

--- a/tools/evaluate_loop_closures.py
+++ b/tools/evaluate_loop_closures.py
@@ -1,0 +1,212 @@
+# This file is part of VIAME, and is distributed under an OSI-approved #
+# BSD 3-Clause License. See either the root top-level LICENSE file or  #
+# https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.    #
+"""Pseudo-evaluation of ``detect_prior_coverage.py`` loop-closure recall.
+
+Independently derives "expected" loop-closure events for a site from raw
+flight-log GPS + altitude (ground footprint overlap between an image and any
+earlier-pass/earlier-day image, using nothing from the imagery pipeline under
+test), then compares that set against the ``image`` column of the tool's own
+``revisits.csv`` to report what fraction of the expected revisits it
+recovered.
+
+This is a coverage/recall check, not ground truth in the strict sense -- the
+flight-log-derived "expected" set is itself an estimate (footprint size is a
+model, not measured), so treat the percentage as an approximate pseudo-score,
+not an exact metric.
+
+Usage::
+
+    evaluate_loop_closures.py SITE_FOLDER --flight-logs DIR \\
+        --revisits-csv OUT_DIR/revisits.csv
+"""
+
+import argparse
+import csv
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import numpy as np
+import cv2
+
+from viame.core import survey_metadata as smd
+
+
+def _quad_overlap_frac(a, b):
+    """Fraction of the smaller quad's area covered by the intersection."""
+    a = np.array(a, dtype=np.float32)
+    b = np.array(b, dtype=np.float32)
+    inter, _ = cv2.intersectConvexConvex(a, b)
+    if not inter or inter <= 0:
+        return 0.0
+    area_a = cv2.contourArea(a)
+    area_b = cv2.contourArea(b)
+    return inter / max(min(area_a, area_b), 1e-6)
+
+
+def expected_loop_closures(site_folder, flight_logs, overlap_thresh=0.15,
+                           min_pass_gap=True, xcam_offset_frac=0.9,
+                           min_frame_gap=0):
+    """Return {rel_path: [(source_rel_path, source_pass, source_day, overlap_frac), ...]}
+    for images whose GPS/altitude-derived footprint overlaps an earlier
+    pass's (or earlier day's, for --all multi-site runs) footprint.
+
+    Footprints come from ``survey_metadata.build_footprints``, which applies the
+    PORT/STAR across-track cant: those cameras look ~0.9 footprint-widths off
+    the aircraft track, so placing their footprint at the aircraft position
+    would misplace it by ~95 m and mis-state which frames really share ground.
+    """
+    fps, cams = smd.build_footprints(site_folder, flight_logs=flight_logs,
+                                     xcam_offset_frac=xcam_offset_frac,
+                                     read_exif=True, verbose=True)
+    day = smd.folder_date(site_folder) or ''
+    if not fps:
+        return {}
+
+    rels = list(fps.keys())
+    passes = {}
+    order = {}
+    for idx, rel in enumerate(rels):
+        try:
+            passes[rel] = int(fps[rel].get('pass') or 1)
+        except (TypeError, ValueError):
+            passes[rel] = 1
+        fr = fps[rel].get('frame')
+        order[rel] = fr if fr is not None else idx
+
+    # When the data has no pass structure (a single continuous flight, e.g. the
+    # 2025 single-camera UAS surveys where every frame is pass 1), a "loop
+    # closure" is the platform returning to re-image the same ground after a
+    # long gap. Detect it by a large capture-order separation + footprint
+    # overlap, so ordinary consecutive-frame overlap (the sequential swath)
+    # does not count. Auto-enabled when only one pass is present.
+    single_pass = len(set(passes.values())) <= 1
+    use_frame_gap = min_frame_gap > 0 and single_pass
+
+    expected = {}
+    for i, rel_i in enumerate(rels):
+        for rel_j in rels[:i]:
+            if use_frame_gap:
+                if abs(order[rel_i] - order[rel_j]) < min_frame_gap:
+                    continue  # too close in time -> sequential overlap, not a revisit
+            elif min_pass_gap and passes[rel_j] >= passes[rel_i]:
+                continue      # only re-covering an EARLIER pass is a revisit
+            frac = _quad_overlap_frac(fps[rel_i]['quad'], fps[rel_j]['quad'])
+            if frac >= overlap_thresh:
+                expected.setdefault(rel_i, []).append(
+                    (rel_j, passes[rel_j], day, frac))
+    return expected
+
+
+def _is_confirmed(row):
+    return str(row.get('confirmed', '')).strip().lower() in ('true', '1', 'yes')
+
+
+def load_detected_images(revisits_csv):
+    detected = {}
+    if not os.path.isfile(revisits_csv):
+        return detected
+    with open(revisits_csv) as f:
+        for row in csv.DictReader(f):
+            detected.setdefault(row['image'], []).append(row)
+    return detected
+
+
+def evaluate(site_folder, flight_logs, revisits_csv, overlap_thresh=0.15,
+             min_frame_gap=0):
+    expected = expected_loop_closures(site_folder, flight_logs, overlap_thresh,
+                                      min_frame_gap=min_frame_gap)
+    detected = load_detected_images(revisits_csv)
+
+    n_expected = len(expected)
+    n_found = sum(1 for rel in expected if rel in detected)
+    recall = (n_found / n_expected) if n_expected else None
+
+    # Rig-level (camera-agnostic) recall. STRICT recall above requires the exact
+    # (camera, frame) image to be flagged. On a PORT/CENTER/STAR rig the pipeline
+    # often credits a re-covered swath to a different camera than the footprint
+    # model expects (e.g. it flags PORT#144 while the expected revisit is
+    # STAR#144 - same trigger, same ground). That reads as 0% strict even though
+    # the rig DID detect the re-coverage. Here an expected revisit is credited if
+    # the rig flagged a revisit at the same TRIGGER (frame number) from any
+    # camera. All three rig cameras share the frame number at a trigger.
+    def _frame(rel):
+        return smd.parse_image_filename(rel).get('frame')
+    detected_frames = {_frame(rel) for rel in detected if _frame(rel) is not None}
+    n_found_rig = sum(1 for rel in expected if _frame(rel) in detected_frames)
+    recall_rig = (n_found_rig / n_expected) if n_expected else None
+
+    # Independent (image-registration-confirmed) subset: of the expected
+    # loop-closures the tool detected, how many did it verify by a direct
+    # land-to-land feature match rather than GPS geometry alone. This is the
+    # honest, non-circular signal -- GPS recall is partly structural because
+    # the tool's hybrid detector reads the same flight log this evaluator does.
+    n_conf = sum(1 for rel in expected
+                 if any(_is_confirmed(r) for r in detected.get(rel, [])))
+    conf_rate = (n_conf / n_found) if n_found else None
+
+    missed = sorted(set(expected) - set(detected))
+    return {
+        'site': os.path.basename(os.path.normpath(site_folder)),
+        'n_expected_images': n_expected,
+        'n_detected_of_expected': n_found,
+        'recall': recall,
+        'n_detected_rig': n_found_rig,
+        'recall_rig': recall_rig,
+        'n_reg_confirmed_of_detected': n_conf,
+        'confirm_rate': conf_rate,
+        'missed_images': missed,
+        'n_detected_total': len(detected),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('site', help='Site folder')
+    ap.add_argument('--flight-logs', default=None)
+    ap.add_argument('--revisits-csv', required=True,
+                    help='revisits.csv produced by detect_prior_coverage.py')
+    ap.add_argument('--overlap-thresh', type=float, default=0.15,
+                    help='Minimum footprint overlap fraction to count as an '
+                    'expected loop-closure/revisit (default 0.15)')
+    ap.add_argument('--show-missed', type=int, default=10,
+                    help='Print up to N missed expected-revisit image names')
+    ap.add_argument('--min-frame-gap', type=int, default=0,
+                    help='For single-pass flights (e.g. 2025 UAS), the capture-'
+                    'order gap beyond which an overlapping footprint counts as a '
+                    'revisit rather than sequential swath overlap (0 = off; '
+                    'try 20). Auto-applies only when the site has one pass.')
+    args = ap.parse_args()
+
+    result = evaluate(args.site, args.flight_logs, args.revisits_csv,
+                      args.overlap_thresh, min_frame_gap=args.min_frame_gap)
+
+    print(f"=== {result['site']} ===")
+    print(f"  Expected revisit images (flight-log GPS footprint overlap, "
+          f">= {args.overlap_thresh*100:.0f}% overlap with an earlier pass): "
+          f"{result['n_expected_images']}")
+    print(f"  Detected by tool (revisits.csv, any images): {result['n_detected_total']}")
+    if result['recall'] is None:
+        print("  No expected revisits for this site (single pass, or passes are "
+              "offset transects with no ground overlap) -- recall not applicable")
+    else:
+        print(f"  Strict (per-camera) recall: {result['n_detected_of_expected']}/"
+              f"{result['n_expected_images']} = {result['recall']*100:.1f}%")
+        print(f"  Rig-level (camera-agnostic) recall: {result['n_detected_rig']}/"
+              f"{result['n_expected_images']} = {result['recall_rig']*100:.1f}%")
+        if result['confirm_rate'] is not None:
+            print(f"  ...of which image-registration-confirmed (independent): "
+                  f"{result['n_reg_confirmed_of_detected']}/"
+                  f"{result['n_detected_of_expected']} = "
+                  f"{result['confirm_rate']*100:.1f}%")
+    if result['missed_images'] and args.show_missed:
+        print(f"  Missed (first {args.show_missed}):")
+        for m in result['missed_images'][:args.show_missed]:
+            print(f"    {m}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/evaluate_loop_closures.py
+++ b/tools/evaluate_loop_closures.py
@@ -1,7 +1,7 @@
 # This file is part of VIAME, and is distributed under an OSI-approved #
 # BSD 3-Clause License. See either the root top-level LICENSE file or  #
 # https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.    #
-"""Pseudo-evaluation of ``detect_prior_coverage.py`` loop-closure recall.
+"""Pseudo-evaluation of ``register.py`` loop-closure recall.
 
 Independently derives "expected" loop-closure events for a site from raw
 flight-log GPS + altitude (ground footprint overlap between an image and any
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import numpy as np
 import cv2
 
-from viame.core import survey_metadata as smd
+import metadata as smd
 
 
 def _quad_overlap_frac(a, b):
@@ -53,7 +53,7 @@ def expected_loop_closures(site_folder, flight_logs, overlap_thresh=0.15,
     for images whose GPS/altitude-derived footprint overlaps an earlier
     pass's (or earlier day's, for --all multi-site runs) footprint.
 
-    Footprints come from ``survey_metadata.build_footprints``, which applies the
+    Footprints come from ``metadata.build_footprints``, which applies the
     PORT/STAR across-track cant: those cameras look ~0.9 footprint-widths off
     the aircraft track, so placing their footprint at the aircraft position
     would misplace it by ~95 m and mis-state which frames really share ground.
@@ -168,7 +168,7 @@ def main():
     ap.add_argument('site', help='Site folder')
     ap.add_argument('--flight-logs', default=None)
     ap.add_argument('--revisits-csv', required=True,
-                    help='revisits.csv produced by detect_prior_coverage.py')
+                    help='revisits.csv produced by register.py')
     ap.add_argument('--overlap-thresh', type=float, default=0.15,
                     help='Minimum footprint overlap fraction to count as an '
                     'expected loop-closure/revisit (default 0.15)')


### PR DESCRIPTION
Rebased onto `main`. The geometry / GPS / imagelog fixes and the 2025 UAS
ingest that originally made up this PR have already landed on `main` (cherry-picked
as `60025e0` + `71f529e`). This PR now contains only the remaining piece that was
omitted in that cherry-pick: the standalone loop-closure evaluation tooling.

The tools import `survey_metadata` / `registration_utils` from the refactored
`viame.core` / `viame.opencv` modules already on `main`.

## What's here

- **`tools/evaluate_loop_closures.py`** — pseudo-evaluates `detect_prior_coverage.py`
  recall by independently deriving expected loop closures from raw flight-log
  GPS + altitude footprint overlap (nothing from the imagery pipeline under test)
  and comparing against the tool's `revisits.csv`. Reports both strict per-camera
  recall and **rig-level (camera-agnostic) recall**, which credits an expected
  revisit if any rig camera flagged it at that trigger — un-masking multi-camera
  sites where the pipeline credits a swath to a different camera than the footprint
  model expects (Nagai Rocks / Egg / Kupreanof: 0% strict → 100% rig-level).
- **`tools/analyze_match_failures.py`** — cross-checks every match the pipeline
  claimed against independent flight-log GPS to catalogue provable false matches
  over open ocean and self-similar tussock grass. Phase 1 is metadata-only;
  `--visualize` re-runs SIFT on flagged pairs for inlier counts and side-by-side
  match images.
- **`tools/build_pixel_mosaic.py`** — builds a pixel-stitched mosaic without the
  compiled KWIVER stabilizer, reusing `registration_utils` for the per-camera
  homography chain, GPS-anchoring failed frames, then running a loop-closure
  pose-graph optimization pass; writes homographies in `create_mosaic.py`'s format.
