### PR TITLE
vertex: prefer regular cuda libs over compat layer to fix driver mismatch

### DIFF
--- a/docker/viame_gpu_vertex_ai.docker
+++ b/docker/viame_gpu_vertex_ai.docker
@@ -18,8 +18,11 @@ ENV VIAME_PIPELINE=pipelines/detector_gmm_motion.pipe
 ENV VIAME_OUTPUT_TYPE=coco
 ENV VIAME_FRAME_RATE=10
 
-# Ensure CUDA forward-compat libs are found when the host driver is older
-ENV LD_LIBRARY_PATH=/usr/local/cuda/compat:${LD_LIBRARY_PATH}
+# Match the LD_LIBRARY_PATH from the official NVIDIA CUDA image so the "regular"
+# cuda libraries are found before the compat layer. Vertex/Cloud Run inject newer
+# NVIDIA drivers than the compat layer's hard-coded support list, so preferring
+# the compat libs causes driver/cuda mismatch failures (see issue #273).
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
 
 ENV AIP_HTTP_PORT=8080
 

--- a/docker/viame_gpu_vertex_ai_with_addon.sh
+++ b/docker/viame_gpu_vertex_ai_with_addon.sh
@@ -90,7 +90,11 @@ WORKDIR /workspace
 
 ENV VIAME_INSTALL_DIR=/opt/noaa/viame
 ENV VIAME_WORK_DIR=/workspace
-ENV LD_LIBRARY_PATH=/usr/local/cuda/compat:${LD_LIBRARY_PATH}
+# Match the LD_LIBRARY_PATH from the official NVIDIA CUDA image so the "regular"
+# cuda libraries are found before the compat layer. Vertex/Cloud Run inject newer
+# NVIDIA drivers than the compat layer's hard-coded support list, so preferring
+# the compat libs causes driver/cuda mismatch failures (see issue #273).
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
 ENV AIP_HTTP_PORT=8080
 DOCKERFILE
 


### PR DESCRIPTION
Fixes #273.

Vertex AI / Cloud Run inject newer NVIDIA drivers than the CUDA compat layer supports (its support list is hard-coded). The dockerfile prepended `/usr/local/cuda/compat` to `LD_LIBRARY_PATH`, so the container hit the compat layer first, failed the driver check, and exited. The regular cuda libraries handle the newer drivers fine.

- Replace the compat-first `LD_LIBRARY_PATH` with the value from the official NVIDIA CUDA image (`/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64`), so the regular libs are found before the compat layer.

This matches fix #2 from the issue, which was tested by the reporter.