### PR TITLE
coco: normalize keypoint ids and timestamps for kwcoco compatibility

### DIFF
--- a/plugins/core/read_object_track_set_coco.py
+++ b/plugins/core/read_object_track_set_coco.py
@@ -28,7 +28,7 @@ import json
 from kwiver.vital.algo import ReadObjectTrackSet
 import kwiver.vital.types as vt
 
-from viame.core.utilities_coco import annotation_to_detection
+from viame.core.utilities_coco import annotation_to_detection, timestamp_to_seconds
 
 
 class ReadObjectTrackSetCoco(ReadObjectTrackSet):
@@ -191,8 +191,9 @@ class ReadObjectTrackSetCoco(ReadObjectTrackSet):
                     ann, categories, image_dims=dims,
                     kp_cat_names=kp_cat_names)
 
-                if timestamp is not None:
-                    time_usec = int(timestamp * 1e6)
+                seconds = timestamp_to_seconds(timestamp)
+                if seconds is not None:
+                    time_usec = int(seconds * 1e6)
                 else:
                     time_usec = frame_index
 

--- a/plugins/core/utilities_coco.py
+++ b/plugins/core/utilities_coco.py
@@ -392,21 +392,59 @@ def build_image_list(images, aux_image_labels, aux_image_extensions):
 
 
 def _collect_keypoint_categories(annotations):
-    """Extract unique keypoint category names from annotation dicts.
+    """Build the keypoint_categories table and stamp each keypoint with its id.
 
-    Returns a list of ``{id, name}`` dicts, or *None* if no keypoints
-    are present.
+    Assigns a name -> id mapping (ids 1-based, in order of first
+    appearance) and injects a ``keypoint_category_id`` into every keypoint
+    dict alongside the existing ``keypoint_category`` name, so files
+    round-trip through readers that key on the id (e.g. DIVE) as well as
+    those that key on the name.
+
+    Returns a list of ``{id, name}`` dicts, or *None* if no keypoints are
+    present.
     """
     names = {}
     for ann in annotations:
         for kp in ann.get('keypoints', []):
             if isinstance(kp, dict):
                 name = kp.get('keypoint_category', '')
-                if name and name not in names:
+                if not name:
+                    continue
+                if name not in names:
                     names[name] = len(names) + 1
+                kp['keypoint_category_id'] = names[name]
     if not names:
         return None
     return [dict(id=i, name=n) for n, i in names.items()]
+
+
+# ------------------------------------------------------------------
+# Timestamp helpers
+# ------------------------------------------------------------------
+
+def seconds_to_iso8601(seconds):
+    """Format a POSIX timestamp (seconds since the epoch) as ISO-8601 UTC."""
+    return datetime.datetime.fromtimestamp(
+        seconds, tz=datetime.timezone.utc).isoformat()
+
+
+def timestamp_to_seconds(ts):
+    """Parse a COCO image ``timestamp`` into a float number of seconds.
+
+    Accepts an ISO-8601 string or a numeric (UNIX) timestamp, matching the
+    kwcoco spec. Returns *None* if the value can't be parsed.
+    """
+    if ts is None:
+        return None
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    try:
+        return datetime.datetime.fromisoformat(ts.replace('Z', '+00:00')).timestamp()
+    except (ValueError, TypeError, AttributeError):
+        try:
+            return float(ts)
+        except (ValueError, TypeError):
+            return None
 
 
 # ------------------------------------------------------------------
@@ -424,6 +462,9 @@ def write_coco_json(file_obj, annotations, images, categories,
     category_dict = [dict(id=i, name=c) for c, i in mapping.items()]
     image_dict = build_image_list(images, aux_image_labels, aux_image_extensions)
 
+    # Stamp keypoint_category_id onto each keypoint before serialising.
+    kp_cats = _collect_keypoint_categories(annotations)
+
     output = dict(
         info=dict(
             year=now.year,
@@ -439,7 +480,6 @@ def write_coco_json(file_obj, annotations, images, categories,
     if tracks is not None:
         output['tracks'] = tracks
 
-    kp_cats = _collect_keypoint_categories(annotations)
     if kp_cats is not None:
         output['keypoint_categories'] = kp_cats
 

--- a/plugins/core/write_object_track_set_coco.py
+++ b/plugins/core/write_object_track_set_coco.py
@@ -19,6 +19,7 @@ from kwiver.vital.algo import WriteObjectTrackSet
 from viame.core.utilities_coco import (
     global_categories,
     detection_to_annotation,
+    seconds_to_iso8601,
     write_coco_json,
 )
 
@@ -150,7 +151,7 @@ class WriteObjectTrackSetCoco(WriteObjectTrackSet):
             if file_name:
                 entry["file_name"] = file_name
             if frame_id in self._frame_times:
-                entry["timestamp"] = self._frame_times[frame_id]
+                entry["timestamp"] = seconds_to_iso8601(self._frame_times[frame_id])
             self.images.append(entry)
         return self._frame_to_image_id[frame_id]
 


### PR DESCRIPTION
Normalizes the COCO/kwcoco output of the core detection/track writers so it round-trips cleanly with kwcoco-based readers.

## Keypoints
- Writer now stamps each keypoint with `keypoint_category_id` (index into the `keypoint_categories` table) in addition to the existing `keypoint_category` name.
- DIVE's kwcoco reader looks keypoints up by `keypoint["keypoint_category_id"]`, so name-only output previously failed to import keypoints into DIVE. Keeping the name means both id-keyed and name-keyed readers work.

## Timestamps
- Image `timestamp` is now written as an ISO-8601 string rather than a raw float of seconds. kwcoco accepts either an ISO-8601 string or a numeric UNIX timestamp; the string form is unambiguous and portable.
- The track reader now parses **both** ISO-8601 and numeric timestamps, so existing files still load.

## Files
- `plugins/core/utilities_coco.py` — `keypoint_category_id` stamping; `seconds_to_iso8601` / `timestamp_to_seconds` helpers
- `plugins/core/write_object_track_set_coco.py` — emit ISO-8601 timestamps
- `plugins/core/read_object_track_set_coco.py` — parse ISO-8601 or numeric timestamps

Field spellings (`timestamp`, `video_id`, `frame_index`, `track_id`, `bbox` xywh, `score`) already matched the kwcoco spec and are unchanged. Verified round-trip on the timestamp helpers and keypoint id stamping.