### PR TITLE
Fetch pytorch on demand instead of carrying it as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,10 +16,6 @@
 [submodule "packages/darknet"]
 	path = packages/darknet
 	url = https://github.com/VIAME/darknet.git
-[submodule "packages/pytorch"]
-	path = packages/pytorch
-	url = https://github.com/pytorch/pytorch.git
-	ignore = dirty
 [submodule "packages/pytorch-libs/torchvision"]
 	path = packages/pytorch-libs/torchvision
 	url = https://github.com/pytorch/vision.git

--- a/cmake/add_project_pytorch.cmake
+++ b/cmake/add_project_pytorch.cmake
@@ -13,6 +13,23 @@ set( PYTORCH_LIBS_TO_BUILD )
 
 if( VIAME_BUILD_PYTORCH_FROM_SOURCE )
   set( PYTORCH_LIBS_TO_BUILD ${PYTORCH_LIBS_TO_BUILD} pytorch )
+
+  # PyTorch is deliberately not a superbuild submodule: a recursive checkout
+  # runs several GB, and only builds that compile it need one at all - the rest
+  # install a wheel. Clone it from the build step that needs it instead.
+  #
+  # Left as a plain variable, not a cache entry, so that bumping the internal
+  # version re-pins the checkout instead of leaving it on whatever tag was
+  # cached first. Override on the command line to build another ref.
+  if( NOT VIAME_PYTORCH_GIT_TAG )
+    set( VIAME_PYTORCH_GIT_TAG "v${PYTORCH_INTERNAL_VERSION}" )
+  endif()
+
+  OnDemandGitPackage( PYTORCH_SOURCE
+    URL https://github.com/pytorch/pytorch.git
+    DIR ${VIAME_PACKAGES_DIR}/pytorch
+    REF ${VIAME_PYTORCH_GIT_TAG}
+    RECURSIVE SHALLOW )
 endif()
 
 if( VIAME_BUILD_TORCHVISION_FROM_SOURCE )
@@ -380,7 +397,14 @@ foreach( LIB ${PYTORCH_LIBS_TO_BUILD} )
   endif()
 
   set( LIBRARY_PATCH_COMMAND "" )
+  set( LIBRARY_DOWNLOAD_ARGS )
   set( PROJECT_DEPS fletch python-deps )
+
+  # Every other package here comes down with the submodules; pytorch is cloned
+  # on demand, so it needs a download step of its own
+  if( "${LIB}" STREQUAL "pytorch" )
+    set( LIBRARY_DOWNLOAD_ARGS DOWNLOAD_COMMAND ${PYTORCH_SOURCE_FETCH_COMMAND} )
+  endif()
 
   if( NOT "${LIB}" STREQUAL "pytorch" )
     set( PROJECT_DEPS ${PROJECT_DEPS} pytorch )
@@ -550,11 +574,28 @@ foreach( LIB ${PYTORCH_LIBS_TO_BUILD} )
     PREFIX ${VIAME_BUILD_PREFIX}
     SOURCE_DIR ${LIBRARY_LOCATION}
     BUILD_IN_SOURCE 1
+    ${LIBRARY_DOWNLOAD_ARGS}
     PATCH_COMMAND ${LIBRARY_PATCH_COMMAND}
     CONFIGURE_COMMAND "${LIBRARY_CONFIGURE_CMD}"
     BUILD_COMMAND ${CONDITIONAL_BUILD_CMD}
     INSTALL_COMMAND ${LIBRARY_PYTHON_INSTALL}
     LIST_SEPARATOR "----" )
+
+  if( "${LIB}" STREQUAL "pytorch" )
+    # Re-run the fetch, and every step downstream of it, when the pin moves
+    ExternalProject_Add_StepDependencies( ${LIB} download
+      ${PYTORCH_SOURCE_REF_FILE} )
+
+    # Has to come after the checkout exists, so it cannot live in the build
+    # server scripts that run before configure
+    ExternalProject_Add_Step( ${LIB} patch_nccl_symmem
+      COMMAND ${CMAKE_COMMAND}
+        -DPYTORCH_SOURCE_DIR=${LIBRARY_LOCATION}
+        -P ${VIAME_CMAKE_DIR}/custom_patch_pytorch_nccl.cmake
+      COMMENT "Disabling PyTorch NCCL symmetric-memory support"
+      DEPENDEES patch
+      DEPENDERS configure )
+  endif()
 
   # CUDA 13's nvcc (cudafe++) mishandles a static_cast in the installed torch
   # ATen/core/List_inl.h header, breaking downstream CUDA extension builds such

--- a/cmake/build_common_functions.sh
+++ b/cmake/build_common_functions.sh
@@ -514,62 +514,6 @@ patch_cudnn_headers() {
 }
 
 # ==============================================================================
-# PYTORCH PATCHING
-# ==============================================================================
-
-# Disable PyTorch's NCCL symmetric-memory support
-# Arguments: $1 = VIAME source directory (default: /viame)
-#
-# The NCCL bundled with PyTorch (2.29.7) exposes a symmetric-memory device API
-# that does not compile under CUDA 12.8: nccl_device.h instantiates OpSum<half>
-# during its host pass, where half has no operator+, so nvcc fails in NCCL's
-# reduce_copy__types.h. That breaks NCCLSymmetricMemory.cu, nccl_extension.cu and
-# ops/nccl_reduce_scatter_offset.cu -> torch_cuda -> the entire build.
-#
-# Both the #include and the four capability macros must go. The macros gate every
-# use of the device API (all #ifdef NCCL_HAS_SYMMEM_*), but the #include sits in a
-# version check rather than a capability check, so dropping the macros alone still
-# pulls in the uncompilable header. With both removed the affected translation
-# units compile to empty bodies. ncclWindow_t and friends come from nccl.h and are
-# unaffected, as are standard NCCL collectives and DDP.
-#
-# Revisit when NCCL or CUDA is bumped.
-patch_pytorch_nccl_symmem() {
-  local source_dir="${1:-/viame}"
-  local header="$source_dir/packages/pytorch/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp"
-
-  echo "Checking PyTorch NCCL symmetric-memory support..."
-
-  if [ ! -f "$header" ]; then
-    echo "PyTorch NCCL symmem header not found, skipping patch"
-    return 0
-  fi
-
-  if grep -q 'VIAME_DISABLE_NCCL_SYMMEM' "$header"; then
-    echo "PyTorch NCCL symmem already disabled (no patching needed)"
-    return 0
-  fi
-
-  local tag='// VIAME_DISABLE_NCCL_SYMMEM (does not compile under CUDA 12.8):'
-
-  sed -i -E \
-    -e "s@^#define (NCCL_HAS_SYMMEM_SUPPORT|NCCL_HAS_SYMMEM_DEVICE_SUPPORT|NCCL_HAS_ONE_SIDED_API|NCCL_DEVICE_HAS_REDUCE_COPY)\$@$tag #define \1@" \
-    -e "s@^#include <nccl_device.h>\$@$tag #include <nccl_device.h>@" \
-    "$header"
-
-  local patched
-  patched=$( grep -c 'VIAME_DISABLE_NCCL_SYMMEM' "$header" )
-
-  if [ "$patched" -ne 5 ]; then
-    echo "ERROR: expected to disable 4 NCCL symmem macros + 1 include, got $patched"
-    echo "       $header has likely changed upstream; the patch needs review"
-    return 1
-  fi
-
-  echo "PyTorch NCCL symmem patching complete"
-}
-
-# ==============================================================================
 # CUDA/CUDNN LIBRARY COPYING
 # ==============================================================================
 

--- a/cmake/build_server_rocky.sh
+++ b/cmake/build_server_rocky.sh
@@ -44,11 +44,9 @@ rm /usr/local/cuda
 rm /usr/local/cuda-12
 mv /usr/local/cuda-12.8 $CUDA_DIRECTORY
 
-# Update VIAME sub git sources
+# Update VIAME sub git sources. PyTorch is not among them: it is cloned by the
+# build itself, and patched there, only when built from source
 update_git_submodules $VIAME_SOURCE_DIR
-
-# Patch PyTorch when required
-patch_pytorch_nccl_symmem $VIAME_SOURCE_DIR || exit 1
 
 setup_build_directory $VIAME_SOURCE_DIR
 

--- a/cmake/common_macros.cmake
+++ b/cmake/common_macros.cmake
@@ -1,4 +1,6 @@
 
+set( VIAME_COMMON_MACROS_DIR "${CMAKE_CURRENT_LIST_DIR}" )
+
 function( FormatPassdownsCond _str _varResult _bothCases _ignoreStr )
   set( _tmpResult "" )
   get_cmake_property( _vars VARIABLES )
@@ -274,53 +276,74 @@ function( ReplaceStringInFile ifile oldstr newstr )
   file( WRITE "${ifile}" "${FILE_CONTENTS}" )
 endfunction()
 
-# Generate a runtime git clone-or-pull command for use in ExternalProject_Add.
-# Uses runtime checks instead of CMake configure-time checks to handle rebuilds
-# correctly. If the directory contains a .git folder, it pulls; otherwise it
-# removes any existing directory and clones fresh.
+# Declare a source package that is cloned on demand instead of being carried as
+# a superbuild git submodule. The very large packages cost every checkout of
+# this repository several GB when they are submodules, even for the majority of
+# builds that never compile them, so they are fetched into packages/ only by
+# the build step that actually needs them.
 #
-# Usage in ExternalProject_Add:
-#   GitCloneOrPullCmd( MY_CMD https://github.com/org/repo.git ${TARGET_DIR} )
-#   ExternalProject_Add( myproject
-#     CONFIGURE_COMMAND ${MY_CMD}
-#     ...
-#   )
+# Sets two variables in the caller's scope:
+#   <prefix>_FETCH_COMMAND - clones or re-syncs the checkout; use as an
+#                            ExternalProject DOWNLOAD_COMMAND
+#   <prefix>_REF_FILE      - file tracking the requested url and ref. Hand it to
+#                            ExternalProject_Add_StepDependencies so that
+#                            bumping the pin re-runs the fetch, and everything
+#                            downstream of it, on its own
 #
-# With optional branch:
-#   GitCloneOrPullCmd( MY_CMD https://github.com/org/repo.git ${TARGET_DIR} my-branch )
+# Arguments:
+#   URL <url>   - repository to clone from (required)
+#   DIR <path>  - where the checkout lives (required)
+#   REF <ref>   - tag, branch or full sha to pin to (default: default branch)
+#   NAME <name> - label for status messages (default: last component of DIR)
+#   RECURSIVE   - also init/update the package's own submodules
+#   SHALLOW     - clone with --depth 1; ignored when REF is a raw sha
+#   TRACK       - re-fetch on every run, only needed for refs that move
 #
-function( GitCloneOrPullCmd _output_var _repo_url _target_dir )
-  set( _branch "${ARGN}" )
+# Usage:
+#   OnDemandGitPackage( PYTORCH_SOURCE
+#     URL https://github.com/pytorch/pytorch.git
+#     DIR ${VIAME_PACKAGES_DIR}/pytorch
+#     REF v2.12.0
+#     RECURSIVE SHALLOW )
+#
+#   ExternalProject_Add( pytorch
+#     DOWNLOAD_COMMAND ${PYTORCH_SOURCE_FETCH_COMMAND}
+#     ... )
+#   ExternalProject_Add_StepDependencies( pytorch download ${PYTORCH_SOURCE_REF_FILE} )
+#
+function( OnDemandGitPackage _prefix )
+  cmake_parse_arguments( _pkg "RECURSIVE;SHALLOW;TRACK" "URL;DIR;REF;NAME" "" ${ARGN} )
 
-  # Generate a unique script name based on target directory
-  string( MD5 _hash "${_target_dir}" )
-  set( _script_dir "${CMAKE_BINARY_DIR}/git_scripts" )
-  set( _script_path "${_script_dir}/git_clone_or_pull_${_hash}.sh" )
-
-  file( MAKE_DIRECTORY "${_script_dir}" )
-
-  if( _branch )
-    set( _clone_cmd "git clone --branch ${_branch} ${_repo_url} ${_target_dir}" )
-  else()
-    set( _clone_cmd "git clone ${_repo_url} ${_target_dir}" )
+  if( NOT _pkg_URL OR NOT _pkg_DIR )
+    message( FATAL_ERROR "OnDemandGitPackage( ${_prefix} ) requires URL and DIR" )
   endif()
 
-  file( WRITE "${_script_path}"
-"#!/bin/sh
-if [ -d \"${_target_dir}/.git\" ]; then
-  echo \"Pulling updates in ${_target_dir}\"
-  git -C \"${_target_dir}\" pull
-else
-  if [ -d \"${_target_dir}\" ]; then
-    echo \"Removing non-git directory ${_target_dir}\"
-    rm -rf \"${_target_dir}\"
-  fi
-  echo \"Cloning ${_repo_url} to ${_target_dir}\"
-  ${_clone_cmd}
-fi
-" )
+  if( NOT _pkg_NAME )
+    get_filename_component( _pkg_NAME "${_pkg_DIR}" NAME )
+  endif()
 
-  set( ${_output_var} sh "${_script_path}" PARENT_SCOPE )
+  set( _fetch_cmd
+    ${CMAKE_COMMAND}
+      -DPKG_NAME:STRING=${_pkg_NAME}
+      -DREPO_URL:STRING=${_pkg_URL}
+      -DTARGET_DIR:PATH=${_pkg_DIR}
+      -DGIT_REF:STRING=${_pkg_REF}
+      -DRECURSIVE:BOOL=${_pkg_RECURSIVE}
+      -DSHALLOW:BOOL=${_pkg_SHALLOW}
+      -DTRACK:BOOL=${_pkg_TRACK}
+      -P ${VIAME_COMMON_MACROS_DIR}/custom_fetch_git_package.cmake )
+
+  # Contents, not presence, have to drive the dependency: routing the write
+  # through configure_file leaves the timestamp alone unless the pin moved
+  set( _ref_file "${CMAKE_BINARY_DIR}/git-packages/${_pkg_NAME}-ref.txt" )
+
+  file( WRITE "${_ref_file}.in"
+    "${_pkg_URL}\n${_pkg_REF}\n"
+    "recursive=${_pkg_RECURSIVE} shallow=${_pkg_SHALLOW} track=${_pkg_TRACK}\n" )
+  configure_file( "${_ref_file}.in" "${_ref_file}" COPYONLY )
+
+  set( ${_prefix}_FETCH_COMMAND "${_fetch_cmd}" PARENT_SCOPE )
+  set( ${_prefix}_REF_FILE "${_ref_file}" PARENT_SCOPE )
 endfunction()
 
 # Remove project CMake stamp file to trigger rebuild.

--- a/cmake/custom_fetch_git_package.cmake
+++ b/cmake/custom_fetch_git_package.cmake
@@ -1,0 +1,190 @@
+# custom_fetch_git_package.cmake
+#
+# Clone, or re-sync, a source package that is fetched on demand instead of
+# being carried as a superbuild git submodule. OnDemandGitPackage() in
+# common_macros.cmake generates the invocation; this is what runs at build
+# time, via cmake -P.
+#
+# Required variables:
+#   PKG_NAME   - Package name, used in status messages
+#   REPO_URL   - Git remote to clone from
+#   TARGET_DIR - Directory the checkout lives in
+#
+# Optional variables:
+#   GIT_REF    - Tag, branch or full sha to check out (default: default branch)
+#   RECURSIVE  - Also init/update the package's own submodules
+#   SHALLOW    - Clone and fetch with --depth 1
+#   TRACK      - Fetch on every run rather than only when the checkout no
+#                longer matches GIT_REF. Needed for refs that move (branches),
+#                pointless for tags and shas.
+
+cmake_minimum_required( VERSION 3.16 )
+
+if( NOT PKG_NAME OR NOT REPO_URL OR NOT TARGET_DIR )
+  message( FATAL_ERROR
+    "custom_fetch_git_package.cmake requires PKG_NAME, REPO_URL and TARGET_DIR" )
+endif()
+
+find_package( Git QUIET )
+
+if( NOT GIT_EXECUTABLE )
+  set( GIT_EXECUTABLE git )
+endif()
+
+# Run a git command, aborting the build if it fails
+function( RunGit _description )
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} ${ARGN}
+    RESULT_VARIABLE _result )
+  if( NOT _result EQUAL 0 )
+    message( FATAL_ERROR "${PKG_NAME}: ${_description} failed with code ${_result}" )
+  endif()
+endfunction()
+
+# Run a git command, returning its trimmed output, or "" if it failed
+function( GitQuery _output_var )
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} ${ARGN}
+    OUTPUT_VARIABLE _stdout
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    RESULT_VARIABLE _result )
+  if( NOT _result EQUAL 0 )
+    set( _stdout "" )
+  endif()
+  set( ${_output_var} "${_stdout}" PARENT_SCOPE )
+endfunction()
+
+# Resolve a ref to a commit within the checkout. The remote-tracking copy wins
+# so that a branch follows the last fetch rather than a stale local branch;
+# tags and shas have no remote-tracking form and fall through to the ref itself.
+function( ResolveRef _ref _output_var )
+  set( _sha "" )
+  if( _ref )
+    GitQuery( _sha -C "${TARGET_DIR}" rev-parse --verify --quiet
+      "refs/remotes/origin/${_ref}^{commit}" )
+    if( NOT _sha )
+      GitQuery( _sha -C "${TARGET_DIR}" rev-parse --verify --quiet "${_ref}^{commit}" )
+    endif()
+  endif()
+  set( ${_output_var} "${_sha}" PARENT_SCOPE )
+endfunction()
+
+# A raw sha cannot be handed to `git clone --branch`, and servers commonly
+# refuse a shallow fetch of an arbitrary sha, so pin-by-sha uses a full clone
+set( REF_IS_SHA FALSE )
+if( GIT_REF MATCHES "^[0-9a-fA-F]{40}$" )
+  set( REF_IS_SHA TRUE )
+  set( SHALLOW FALSE )
+endif()
+
+# A leftover submodule checkout has a .git file rather than a directory, so ask
+# git rather than testing for a directory
+set( HAVE_CHECKOUT FALSE )
+if( EXISTS "${TARGET_DIR}/.git" )
+  GitQuery( _git_dir -C "${TARGET_DIR}" rev-parse --git-dir )
+  if( _git_dir )
+    set( HAVE_CHECKOUT TRUE )
+  endif()
+endif()
+
+if( NOT HAVE_CHECKOUT )
+  if( EXISTS "${TARGET_DIR}" )
+    file( GLOB _leftovers "${TARGET_DIR}/*" "${TARGET_DIR}/.??*" )
+    if( _leftovers )
+      message( STATUS "${PKG_NAME}: removing non-git directory ${TARGET_DIR}" )
+      file( REMOVE_RECURSE "${TARGET_DIR}" )
+    endif()
+  endif()
+
+  get_filename_component( _parent_dir "${TARGET_DIR}" DIRECTORY )
+  file( MAKE_DIRECTORY "${_parent_dir}" )
+
+  set( _clone_args clone )
+  if( SHALLOW )
+    list( APPEND _clone_args --depth 1 )
+  endif()
+  if( GIT_REF AND NOT REF_IS_SHA )
+    list( APPEND _clone_args --branch "${GIT_REF}" )
+  endif()
+  list( APPEND _clone_args "${REPO_URL}" "${TARGET_DIR}" )
+
+  message( STATUS "${PKG_NAME}: cloning ${REPO_URL} into ${TARGET_DIR}" )
+  RunGit( "clone of ${REPO_URL}" ${_clone_args} )
+endif()
+
+# Keep the remote pointed at the configured url, so a moved upstream is picked
+# up without anyone having to delete the checkout by hand
+GitQuery( _origin_url -C "${TARGET_DIR}" remote get-url origin )
+
+if( NOT "${_origin_url}" STREQUAL "${REPO_URL}" )
+  if( _origin_url )
+    message( STATUS "${PKG_NAME}: origin url ${_origin_url} -> ${REPO_URL}" )
+    RunGit( "remote set-url" -C "${TARGET_DIR}" remote set-url origin "${REPO_URL}" )
+  else()
+    RunGit( "remote add" -C "${TARGET_DIR}" remote add origin "${REPO_URL}" )
+  endif()
+endif()
+
+GitQuery( _head_sha -C "${TARGET_DIR}" rev-parse --verify --quiet "HEAD^{commit}" )
+ResolveRef( "${GIT_REF}" _want_sha )
+
+# Nothing to do, and no network round trip, while the pin still matches what is
+# checked out. A bumped pin no longer resolves to HEAD and drops through
+set( NEED_FETCH TRUE )
+if( GIT_REF AND NOT TRACK AND _want_sha AND _want_sha STREQUAL "${_head_sha}" )
+  set( NEED_FETCH FALSE )
+endif()
+
+if( NEED_FETCH )
+  set( _fetch_args -C "${TARGET_DIR}" fetch --force --tags )
+  if( SHALLOW )
+    list( APPEND _fetch_args --depth 1 )
+  endif()
+  list( APPEND _fetch_args origin )
+  if( GIT_REF )
+    list( APPEND _fetch_args "${GIT_REF}" )
+  endif()
+
+  message( STATUS "${PKG_NAME}: fetching ${GIT_REF} from ${REPO_URL}" )
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} ${_fetch_args}
+    RESULT_VARIABLE _fetch_result )
+
+  if( NOT _fetch_result EQUAL 0 )
+    # Not every server serves a ref asked for by name, notably raw shas, so try
+    # everything the remote has before giving up
+    message( STATUS "${PKG_NAME}: fetch of ${GIT_REF} failed, fetching all refs" )
+    RunGit( "fetch from ${REPO_URL}" -C "${TARGET_DIR}" fetch --force --tags origin )
+  endif()
+
+  ResolveRef( "${GIT_REF}" _want_sha )
+  if( NOT _want_sha )
+    GitQuery( _want_sha -C "${TARGET_DIR}" rev-parse --verify --quiet "FETCH_HEAD^{commit}" )
+  endif()
+  if( NOT _want_sha )
+    message( FATAL_ERROR "${PKG_NAME}: unable to resolve '${GIT_REF}' in ${TARGET_DIR}" )
+  endif()
+endif()
+
+if( NOT _want_sha STREQUAL "${_head_sha}" )
+  # --force because build steps patch these trees in place; the patch step runs
+  # after this one and puts its overlay back
+  message( STATUS "${PKG_NAME}: checking out ${GIT_REF} (${_want_sha})" )
+  RunGit( "checkout of ${GIT_REF}" -C "${TARGET_DIR}"
+    checkout --force --detach "${_want_sha}" )
+else()
+  message( STATUS "${PKG_NAME}: already at ${GIT_REF} (${_head_sha})" )
+endif()
+
+if( CMAKE_HOST_WIN32 )
+  # Some packages, pytorch's composable_kernel among them, carry submodule
+  # paths past the 260 character default limit and fail the update without this
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} -C "${TARGET_DIR}" config core.longpaths true )
+endif()
+
+if( RECURSIVE )
+  message( STATUS "${PKG_NAME}: updating submodules" )
+  RunGit( "submodule update" -C "${TARGET_DIR}" submodule update --init --recursive )
+endif()

--- a/cmake/custom_patch_pytorch_nccl.cmake
+++ b/cmake/custom_patch_pytorch_nccl.cmake
@@ -1,0 +1,80 @@
+# custom_patch_pytorch_nccl.cmake
+#
+# Disable PyTorch's NCCL symmetric-memory support.
+#
+# The NCCL bundled with PyTorch (2.29.7) exposes a symmetric-memory device API
+# that does not compile under CUDA 12.8: nccl_device.h instantiates OpSum<half>
+# during its host pass, where half has no operator+, so nvcc fails in NCCL's
+# reduce_copy__types.h. That breaks NCCLSymmetricMemory.cu, nccl_extension.cu and
+# ops/nccl_reduce_scatter_offset.cu -> torch_cuda -> the entire build.
+#
+# Both the #include and the four capability macros must go. The macros gate every
+# use of the device API (all #ifdef NCCL_HAS_SYMMEM_*), but the #include sits in a
+# version check rather than a capability check, so dropping the macros alone still
+# pulls in the uncompilable header. With both removed the affected translation
+# units compile to empty bodies. ncclWindow_t and friends come from nccl.h and are
+# unaffected, as are standard NCCL collectives and DDP.
+#
+# Revisit when NCCL or CUDA is bumped.
+#
+# Required variables:
+#   PYTORCH_SOURCE_DIR - Root of the PyTorch checkout
+
+cmake_minimum_required( VERSION 3.16 )
+
+if( NOT PYTORCH_SOURCE_DIR )
+  message( FATAL_ERROR "custom_patch_pytorch_nccl.cmake requires PYTORCH_SOURCE_DIR" )
+endif()
+
+set( HEADER
+  "${PYTORCH_SOURCE_DIR}/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp" )
+
+if( NOT EXISTS "${HEADER}" )
+  message( STATUS "PyTorch NCCL symmem header not found, skipping patch" )
+  return()
+endif()
+
+set( TAG "// VIAME_DISABLE_NCCL_SYMMEM (does not compile under CUDA 12.8):" )
+
+file( READ "${HEADER}" CONTENTS )
+
+if( CONTENTS MATCHES "VIAME_DISABLE_NCCL_SYMMEM" )
+  message( STATUS "PyTorch NCCL symmem already disabled (no patching needed)" )
+  return()
+endif()
+
+# Split into lines by hand so that anchors apply per line, protecting any
+# semicolons in the source from being read as list separators on the way
+string( REPLACE ";" "<SEMICOLON>" CONTENTS "${CONTENTS}" )
+string( REPLACE "\n" ";" LINES "${CONTENTS}" )
+
+set( MACROS
+  "NCCL_HAS_SYMMEM_SUPPORT|NCCL_HAS_SYMMEM_DEVICE_SUPPORT|NCCL_HAS_ONE_SIDED_API|NCCL_DEVICE_HAS_REDUCE_COPY" )
+
+set( PATCHED_LINES )
+set( PATCHED_COUNT 0 )
+
+foreach( LINE IN LISTS LINES )
+  string( REGEX REPLACE "\r$" "" STRIPPED "${LINE}" )
+
+  if( STRIPPED MATCHES "^#define (${MACROS})$" OR
+      STRIPPED STREQUAL "#include <nccl_device.h>" )
+    list( APPEND PATCHED_LINES "${TAG} ${LINE}" )
+    math( EXPR PATCHED_COUNT "${PATCHED_COUNT} + 1" )
+  else()
+    list( APPEND PATCHED_LINES "${LINE}" )
+  endif()
+endforeach()
+
+if( NOT PATCHED_COUNT EQUAL 5 )
+  message( FATAL_ERROR
+    "Expected to disable 4 NCCL symmem macros + 1 include, got ${PATCHED_COUNT}\n"
+    "  ${HEADER} has likely changed upstream; the patch needs review" )
+endif()
+
+string( REPLACE ";" "\n" PATCHED "${PATCHED_LINES}" )
+string( REPLACE "<SEMICOLON>" ";" PATCHED "${PATCHED}" )
+
+file( WRITE "${HEADER}" "${PATCHED}" )
+
+message( STATUS "PyTorch NCCL symmem patching complete" )

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,0 +1,3 @@
+# Packages cloned on demand by the build rather than checked out as submodules
+# (see OnDemandGitPackage in cmake/common_macros.cmake)
+pytorch/


### PR DESCRIPTION
`packages/pytorch` was a submodule, so every checkout paid for a multi-GB tree that only source builds of torch use. Same treatment `packages/learn*` used to get.

- `OnDemandGitPackage()` in `common_macros.cmake` replaces `GitCloneOrPullCmd`: `cmake -P` instead of a generated `sh` script, pins to tag/branch/sha, optional shallow + recursive, detects an existing checkout via git (so a leftover submodule works), re-points `origin` when the url moves.
- Auto-updates when the pin moves: the fetch skips the network while the ref still resolves to HEAD, and the emitted ref file is a download-step dependency, so a version bump re-runs the fetch and everything downstream.
- pytorch pinned to `v${PYTORCH_INTERNAL_VERSION}`, overridable via `VIAME_PYTORCH_GIT_TAG`, fetched only under `VIAME_BUILD_PYTORCH_FROM_SOURCE` — the wheel path needs no source.
- NCCL symmem patch moved from `build_common_functions.sh` to a patch step on the pytorch project. The shell copy ran before configure, where the checkout no longer exists, and would have silently stopped applying. Output is byte-identical to the old sed.

Tested against local fixture repos: fresh clone, no-op rebuild (no network), pin bump, dirty tree, sha pin, branch + TRACK, url change, and the ExternalProject step-dependency wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)