### PR TITLE
Take the stereo calibration from DIVE instead of a global directory

### DIFF
--- a/configs/add-ons/ifremer/calibration_params.conf
+++ b/configs/add-ons/ifremer/calibration_params.conf
@@ -6,7 +6,8 @@
 # =============================================================================
 
 config global
-   :output_directory                           /home/<user>/calibration_results/
+   # Trailing slash required: consumers concatenate this directly onto a filename.
+   :output_directory                           ./
    :target_width_value                         9
    :target_height_value                        6
    :square_size_value                          10.

--- a/configs/add-ons/ifremer/measurement_detect_fish_only.pipe
+++ b/configs/add-ons/ifremer/measurement_detect_fish_only.pipe
@@ -2,6 +2,9 @@
 # Title: Stereo detect fish
 #
 # Description: Pipeline for measuring object dimensions in imagery.
+#
+# Requires Calibration: True
+# Calibration Keys: depth_map:computer:ocv_stereo_disparity:calibration_file stereo_pairing:calibration_file
 # =============================================================================
 
 config _pipeline:_edge
@@ -11,8 +14,6 @@ config _scheduler
    :type                         pythread_per_process
 
 config global
-   :input_cameras_directory                     /home/<user>/Desktop/viame_tests/camera_calibrations
-   :output_depths_directory                     /home/<user>/Desktop/viame_tests/depthMap
    :pairing_method                              PAIRING_RECTIFIED_IOU
    :iou_pair_threshold                          0.1
 
@@ -38,7 +39,8 @@ block computer:ocv_stereo_disparity
   :block_size                                	11
   :speckle_window_size			                0
   :speckle_range				                0
-  :calibration_file                             $CONFIG{global:input_cameras_directory}
+  # Bound to the dataset's calibration by the Calibration Keys header above.
+  :calibration_file                             calibration_matrices.npz
   :use_wls_filter                               true
 endblock
 
@@ -64,7 +66,8 @@ process detector_writer2
 
 process stereo_pairing
   ::ocv_pair_stereo_detections
-  :cameras_directory                      $CONFIG{global:input_cameras_directory}
+  # Bound to the dataset's calibration by the Calibration Keys header above.
+  :calibration_file                      calibration_matrices.npz
   :pairing_method                         $CONFIG{global:pairing_method}
   :iou_pair_threshold                     $CONFIG{global:iou_pair_threshold}
 

--- a/configs/add-ons/ifremer/measurement_track_fish_in_3d_from_rect_disp.pipe
+++ b/configs/add-ons/ifremer/measurement_track_fish_in_3d_from_rect_disp.pipe
@@ -4,14 +4,14 @@
 # Description: Pipeline for measuring object dimensions in imagery.
 #
 # Requires Calibration: True
+# Calibration Keys: depth_map:computer:ocv_stereo_disparity:calibration_file stereo_pairing:calibration_file
 # =============================================================================
 
 config _pipeline:_edge
        :capacity                               5
 
 config global
-   :input_cameras_directory                    /home/<user>/Desktop/viame_tests/camera_calibrations     # DIVE_PARAM["Calibrations Directory", folder]
-   :output_depths_directory                    /home/<user>/Desktop/viame_tests/depthMap                # DIVE_PARAM["Output Depths Directory", folder]
+   :output_depths_directory                    .                                                       # DIVE_PARAM["Output Depths Directory", folder]
    :min_detection_number_threshold              0
    :max_detection_number_threshold              1000000
    :min_detection_surface_threshold_pix         0
@@ -39,7 +39,8 @@ block computer:ocv_stereo_disparity
   :block_size                                	11          # DIVE_PARAM["Block Size", strictly_positive_int]
   :speckle_window_size			                0
   :speckle_range				                0
-  :calibration_file                             $CONFIG{global:input_cameras_directory}
+  # Bound to the dataset's calibration by the Calibration Keys header above.
+  :calibration_file                             calibration_matrices.npz
   :use_wls_filter                               true
 endblock
 
@@ -50,7 +51,8 @@ connect from downsampler.output_3
 
 process stereo_pairing
   ::ocv_pair_stereo_tracks
-  :cameras_directory                      $CONFIG{global:input_cameras_directory}
+  # Bound to the dataset's calibration by the Calibration Keys header above.
+  :calibration_file                      calibration_matrices.npz
   :min_detection_number_threshold         $CONFIG{global:min_detection_number_threshold}
   :max_detection_number_threshold         $CONFIG{global:max_detection_number_threshold}
   :min_detection_surface_threshold_pix    $CONFIG{global:min_detection_surface_threshold_pix}

--- a/configs/add-ons/ifremer/stereo_calibrate_cameras.conf
+++ b/configs/add-ons/ifremer/stereo_calibrate_cameras.conf
@@ -13,8 +13,8 @@
 # Editable parameters
 # ===========================================================================================
 config global
-   :cameras_directory                           $ENV{VIAME_INSTALL}/configs/camera_calibration
-   :disparity_depth_directory                   /home/<user>/output_depthMap
+   :output_cameras_directory                    .
+   :disparity_depth_directory                   .
    :image_width                                 1280
    :image_height                                720
    :frame_count_threshold                       50
@@ -26,7 +26,7 @@ config global
 # Parameter forwarding to KWIVER pipeline
 # ===========================================================================================
 config cameras_calibration
-  :output_cameras_directory                    $CONFIG{global:cameras_directory}
+  :output_cameras_directory                    $CONFIG{global:output_cameras_directory}
   :image_width                                 $CONFIG{global:image_width}
   :image_height                                $CONFIG{global:image_height}
   :frame_count_threshold                       $CONFIG{global:frame_count_threshold}
@@ -41,8 +41,10 @@ config detector2
   :detector:ocv_detect_calibration_targets:target_height  $CONFIG{global:target_height}
   :detector:ocv_detect_calibration_targets:square_size    $CONFIG{global:square_size}
   
+# Reads back the calibration this same run writes to global:output_cameras_directory,
+# as the OpenCV intrinsics.yml / extrinsics.yml pair.
 config depth_map:computer:ocv_stereo_disparity
-  :calibration_file                      	   $CONFIG{global:cameras_directory}
+  :calibration_file                      	   $CONFIG{global:output_cameras_directory}
   
 config output
   :file_name_template                          $CONFIG{global:disparity_depth_directory}/depth_map%06d.png

--- a/configs/add-ons/ifremer/stereo_track_fish_1280.conf
+++ b/configs/add-ons/ifremer/stereo_track_fish_1280.conf
@@ -13,8 +13,7 @@
 # Editable parameters
 # ===========================================================================================
 config global
-    :input_cameras_directory                    $ENV{VIAME_INSTALL}/configs/camera_calibration
-    :output_depths_directory                    /home/<user>/output_depthMap
+    :output_depths_directory                    .
     :detection_chip_width			            1280
     :detection_chip_height			            1280
     :detection_chip_step			            360
@@ -61,11 +60,13 @@ config tracker2
     :track_search_threshold                     $CONFIG{global:track_search_threshold}
     :similarity_threshold                       $CONFIG{global:similarity_threshold}
 
+# Calibration is bound to these two keys by the pipe's Calibration Keys header;
+# the values here are only the fallback when no calibration is attached.
 config depth_map:computer:ocv_stereo_disparity
-    :calibration_file                           $CONFIG{global:input_cameras_directory}
+    :calibration_file                           calibration_matrices.npz
 
 config stereo_pairing
-    :cameras_directory                          $CONFIG{global:input_cameras_directory}
+    :calibration_file                           calibration_matrices.npz
     :min_detection_number_threshold             $CONFIG{global:min_detection_number_threshold}
     :max_detection_number_threshold             $CONFIG{global:max_detection_number_threshold}
     :min_detection_surface_threshold_pix        $CONFIG{global:min_detection_surface_threshold_pix}

--- a/configs/add-ons/ifremer/stereo_track_fish_720.conf
+++ b/configs/add-ons/ifremer/stereo_track_fish_720.conf
@@ -13,8 +13,7 @@
 # Editable parameters
 # ===========================================================================================
 config global
-    :input_cameras_directory                    $ENV{VIAME_INSTALL}/configs/camera_calibration
-    :output_depths_directory                    /home/<user>/output_depthMap
+    :output_depths_directory                    .
     :detection_chip_width			                  1280
     :detection_chip_height			                720
     :detection_chip_step			                  360
@@ -61,11 +60,13 @@ config tracker2
     :track_search_threshold                     $CONFIG{global:track_search_threshold}
     :similarity_threshold                       $CONFIG{global:similarity_threshold}
 
+# Calibration is bound to these two keys by the pipe's Calibration Keys header;
+# the values here are only the fallback when no calibration is attached.
 config depth_map:computer:ocv_stereo_disparity
-    :calibration_file                           $CONFIG{global:input_cameras_directory}
+    :calibration_file                           calibration_matrices.npz
 
 config stereo_pairing
-    :cameras_directory                          $CONFIG{global:input_cameras_directory}
+    :calibration_file                           calibration_matrices.npz
     :min_detection_number_threshold             $CONFIG{global:min_detection_number_threshold}
     :max_detection_number_threshold             $CONFIG{global:max_detection_number_threshold}
     :min_detection_surface_threshold_pix        $CONFIG{global:min_detection_surface_threshold_pix}

--- a/configs/pipelines/measurement_compute_rectified_disparity.pipe
+++ b/configs/pipelines/measurement_compute_rectified_disparity.pipe
@@ -4,14 +4,14 @@
 # Description: Pipeline for measuring object dimensions in imagery.
 #
 # Requires Calibration: True
+# Calibration Keys: depth_map:computer:ocv_stereo_disparity:calibration_file
 # =============================================================================
 
 config _pipeline:_edge
        :capacity                               5
 
 config global
-   :input_cameras_directory                    /home/<user>/Desktop/viame_tests/camera_calibrations         # DIVE_PARAM["Calibrations Directory", folder]
-   :output_depths_directory                    /home/<user>/Desktop/viame_tests/depthMap                    # DIVE_PARAM["Output Depths Directory", folder]
+   :output_depths_directory                    .                                                            # DIVE_PARAM["Output Depths Directory", folder]
 
 # ================================ VIDEO INPUT ================================
 
@@ -31,7 +31,8 @@ block computer:ocv_stereo_disparity
   :block_size                                	11          # DIVE_PARAM["Block Size", strictly_positive_int]
   :speckle_window_size			                0
   :speckle_range				                0
-  :calibration_file                             $CONFIG{global:input_cameras_directory}
+  # Bound to the dataset's calibration by the Calibration Keys header above.
+  :calibration_file                             calibration_matrices.npz
   :use_wls_filter                               true
 endblock
 

--- a/configs/pipelines/measurement_compute_rectified_disparity.pipe
+++ b/configs/pipelines/measurement_compute_rectified_disparity.pipe
@@ -11,7 +11,7 @@ config _pipeline:_edge
        :capacity                               5
 
 config global
-   :output_depths_directory                    .                                                            # DIVE_PARAM["Output Depths Directory", folder]
+   :output_depths_directory                    .
 
 # ================================ VIDEO INPUT ================================
 
@@ -24,6 +24,13 @@ process depth_map
   :computer:type                              ocv_stereo_disparity
 
 block computer:ocv_stereo_disparity
+  # Output params
+  :compute_depth                                false       # DIVE_PARAM["Compute Depth", bool]
+  :output_rectified                             true        # DIVE_PARAM["Output Rectified", bool]
+  :output_format                                uint16_scaled
+  :uint16_scale_factor                          256.0       # DIVE_PARAM["Scale Factor", strictly_positive_float]
+  :export_as_alpha                              false       # DIVE_PARAM["Export as Alpha Channel", bool]
+
   :algorithm                                 	SGBM
   :min_disparity                             	0           # DIVE_PARAM["Min Disparity", positive_int]
   :num_disparities                           	240         # DIVE_PARAM["Num Disparities", positive_int]
@@ -31,6 +38,7 @@ block computer:ocv_stereo_disparity
   :block_size                                	11          # DIVE_PARAM["Block Size", strictly_positive_int]
   :speckle_window_size			                0
   :speckle_range				                0
+
   # Bound to the dataset's calibration by the Calibration Keys header above.
   :calibration_file                             calibration_matrices.npz
   :use_wls_filter                               true
@@ -45,7 +53,7 @@ connect from downsampler.output_3
 
 process output
   :: image_writer
-  :file_name_template                          $CONFIG{global:output_depths_directory}/depth_map%06d.png
+  :file_name_template                          $CONFIG{global:output_depths_directory}/map%06d.png
   :image_writer:type                           ocv
 
 connect from depth_map.depth_map

--- a/plugins/opencv/calibrate_stereo_cameras.cxx
+++ b/plugins/opencv/calibrate_stereo_cameras.cxx
@@ -9,8 +9,11 @@
 
 #include "calibrate_stereo_cameras.h"
 #include "calibrate_single_camera.h"
+#include "camera_rig_io.h"
 
 #include <vital/types/camera_intrinsics.h>
+#include <vital/types/camera_perspective.h>
+#include <vital/types/camera_rig.h>
 
 #include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -846,53 +849,119 @@ calibrate_stereo_cameras::write_calibration_npz(
 }
 
 // -----------------------------------------------------------------------------
-bool
-calibrate_stereo_cameras::load_calibration_opencv(
-  const std::string& input_directory,
-  calibrate_stereo_cameras_result& result ) const
-{
-  std::string intrinsics_file = input_directory + "/intrinsics.yml";
-  std::string extrinsics_file = input_directory + "/extrinsics.yml";
+namespace {
 
-  // Load intrinsics
-  cv::FileStorage fs_intr( intrinsics_file, cv::FileStorage::READ );
-  if( !fs_intr.isOpened() )
+/// Copy a stereo rig's intrinsics and right-relative-to-left extrinsics into a
+/// calibration result. Mirrors the conversion the measurement bindings use, so
+/// every format read_stereo_rig understands lands here identically.
+bool
+rig_to_calibration_result(
+  kv::camera_rig_stereo_sptr const& rig,
+  calibrate_stereo_cameras_result& result )
+{
+  auto const left =
+    std::dynamic_pointer_cast< kv::camera_perspective >( rig->left() );
+  auto const right =
+    std::dynamic_pointer_cast< kv::camera_perspective >( rig->right() );
+
+  if( !left || !right || !left->intrinsics() || !right->intrinsics() )
   {
-    LOG_ERROR( d->m_logger, "Cannot open intrinsics file: " << intrinsics_file );
     return false;
   }
 
-  fs_intr["M1"] >> result.left.camera_matrix;
-  fs_intr["D1"] >> result.left.dist_coeffs;
-  fs_intr["M2"] >> result.right.camera_matrix;
-  fs_intr["D2"] >> result.right.dist_coeffs;
-  fs_intr.release();
+  auto const to_dist = []( kv::camera_intrinsics_sptr const& ci )
+  {
+    auto const& d = ci->dist_coeffs();
+    cv::Mat out( 1, static_cast< int >( d.size() ), CV_64F );
+    for( size_t i = 0; i < d.size(); ++i )
+    {
+      out.at< double >( 0, static_cast< int >( i ) ) = d[ i ];
+    }
+    return out;
+  };
+
+  cv::eigen2cv( kv::matrix_3x3d( left->intrinsics()->as_matrix() ),
+                result.left.camera_matrix );
+  cv::eigen2cv( kv::matrix_3x3d( right->intrinsics()->as_matrix() ),
+                result.right.camera_matrix );
+  result.left.dist_coeffs = to_dist( left->intrinsics() );
+  result.right.dist_coeffs = to_dist( right->intrinsics() );
+
+  // Right camera relative to the left. Derived from the absolute poses so it
+  // stays correct when the left camera is not at the identity pose.
+  kv::matrix_3x3d const r_left = left->rotation().matrix();
+  kv::matrix_3x3d const r_right = right->rotation().matrix();
+  kv::matrix_3x3d const rotation = r_right * r_left.transpose();
+  kv::vector_3d const translation = r_right * ( left->center() - right->center() );
+
+  cv::eigen2cv( rotation, result.R );
+  cv::eigen2cv( kv::vector_3d( translation ), result.T );
 
   result.left.success = !result.left.camera_matrix.empty();
   result.right.success = !result.right.camera_matrix.empty();
+  result.success = result.left.success && result.right.success &&
+                   !result.R.empty() && !result.T.empty();
+  return result.success;
+}
 
-  // Load extrinsics
-  cv::FileStorage fs_extr( extrinsics_file, cv::FileStorage::READ );
-  if( !fs_extr.isOpened() )
+} // end anonymous namespace
+
+// -----------------------------------------------------------------------------
+bool
+calibrate_stereo_cameras::ensure_rectification(
+  calibrate_stereo_cameras_result& result,
+  const cv::Size& image_size )
+{
+  if( !result.R1.empty() && !result.P1.empty() && !result.Q.empty() )
   {
-    LOG_ERROR( d->m_logger, "Cannot open extrinsics file: " << extrinsics_file );
+    return true;
+  }
+
+  if( result.left.camera_matrix.empty() || result.right.camera_matrix.empty() ||
+      result.R.empty() || result.T.empty() || image_size.area() <= 0 )
+  {
     return false;
   }
 
-  fs_extr["R"] >> result.R;
-  fs_extr["T"] >> result.T;
-  fs_extr["R1"] >> result.R1;
-  fs_extr["R2"] >> result.R2;
-  fs_extr["P1"] >> result.P1;
-  fs_extr["P2"] >> result.P2;
-  fs_extr["Q"] >> result.Q;
-  fs_extr.release();
+  cv::stereoRectify(
+    result.left.camera_matrix, result.left.dist_coeffs,
+    result.right.camera_matrix, result.right.dist_coeffs,
+    image_size, result.R, result.T,
+    result.R1, result.R2, result.P1, result.P2, result.Q,
+    cv::CALIB_ZERO_DISPARITY, 0 );
 
-  result.success = result.left.success && result.right.success &&
-                   !result.R.empty() && !result.T.empty();
+  result.image_size = image_size;
+  return !result.R1.empty() && !result.Q.empty();
+}
 
-  LOG_DEBUG( d->m_logger, "Loaded calibration from: " << input_directory );
-  return result.success;
+// -----------------------------------------------------------------------------
+bool
+calibrate_stereo_cameras::load_calibration(
+  const std::string& calibration_file,
+  calibrate_stereo_cameras_result& result ) const
+{
+  kv::camera_rig_stereo_sptr rig;
+  try
+  {
+    rig = viame::read_stereo_rig( calibration_file );
+  }
+  catch( const std::exception& e )
+  {
+    LOG_ERROR( d->m_logger,
+      "Cannot read calibration " << calibration_file << ": " << e.what() );
+    return false;
+  }
+
+  if( !rig || !rig_to_calibration_result( rig, result ) )
+  {
+    LOG_ERROR( d->m_logger, "Cannot read calibration: " << calibration_file );
+    return false;
+  }
+
+  // The rig carries no rectification transforms; ensure_rectification derives
+  // them once the image size is known.
+  LOG_DEBUG( d->m_logger, "Loaded calibration from: " << calibration_file );
+  return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/plugins/opencv/calibrate_stereo_cameras.h
+++ b/plugins/opencv/calibrate_stereo_cameras.h
@@ -247,14 +247,34 @@ public:
     const calibrate_stereo_cameras_result& result,
     const std::string& filename ) const;
 
-  /// Load calibration from OpenCV YAML files (intrinsics.yml + extrinsics.yml)
+  /// Load a stereo calibration through viame::read_stereo_rig
   ///
-  /// \param input_directory Directory containing calibration files
+  /// Accepts every format the shared reader handles: .json, .yml/.yaml, .npz,
+  /// .mat, and an OpenCV calibration directory of intrinsics.yml +
+  /// extrinsics.yml. None of them carry the rectification transforms in a form
+  /// the rig can hold, so those are left empty for \ref ensure_rectification to
+  /// derive once the image size is known.
+  ///
+  /// \param calibration_file Calibration file, or OpenCV calibration directory
   /// \param[out] result Loaded calibration result
   /// \return true on success
-  bool load_calibration_opencv(
-    const std::string& input_directory,
+  bool load_calibration(
+    const std::string& calibration_file,
     calibrate_stereo_cameras_result& result ) const;
+
+  /// Derive the rectification transforms if the loaded calibration lacks them
+  ///
+  /// Calibration formats other than the OpenCV directory pair store no
+  /// rectification transforms, and stereoRectify cannot run until an image size
+  /// is known. Call this once the first image arrives; it is a no-op when the
+  /// transforms are already populated.
+  ///
+  /// \param[in,out] result Calibration to complete in place
+  /// \param image_size Size of the images the calibration will be applied to
+  /// \return true if the calibration has usable rectification transforms
+  static bool ensure_rectification(
+    calibrate_stereo_cameras_result& result,
+    const cv::Size& image_size );
 
   // -------------------------------------------------------------------------
   // Utility Methods

--- a/plugins/opencv/compute_stereo_disparity.cxx
+++ b/plugins/opencv/compute_stereo_disparity.cxx
@@ -7,6 +7,7 @@
 
 #include <vital/vital_config.h>
 #include <vital/types/image_container.h>
+#include <vital/types/image.h>
 #include <vital/exceptions.h>
 #include <vital/logger/logger.h>
 
@@ -36,11 +37,11 @@ public:
   int speckle_range{ 32 };
 
   // Output format: "raw", "float32", or "uint16_scaled"
+  bool compute_depth{ false };
+  bool export_as_alpha{ false };
+  bool output_rectified{ true };
   std::string output_format{ "raw" };
-
-  // Alpha channel output options
-  bool disparity_as_alpha{ false };
-  bool invert_disparity_alpha{ false };
+  double uint16_scale_factor{ 256.0 };
 
   // WLS filtering
   bool use_wls_filter{ false };
@@ -55,6 +56,8 @@ public:
   mutable cv::Mat rectification_map_left_y;
   mutable cv::Mat rectification_map_right_x;
   mutable cv::Mat rectification_map_right_y;
+  mutable cv::Mat unrectification_map_x;
+  mutable cv::Mat unrectification_map_y;
 
   // Calibration data (loaded if calibration_file is set). Mutable because
   // single-file formats carry no rectification transforms, so those are filled
@@ -146,14 +149,37 @@ public:
     cv::initUndistortRectifyMap(
       calibration.left.camera_matrix, calibration.left.dist_coeffs,
       calibration.R1, calibration.P1,
-      img_size, CV_16SC2,
+      img_size, CV_32FC1,
       rectification_map_left_x, rectification_map_left_y );
 
     cv::initUndistortRectifyMap(
       calibration.right.camera_matrix, calibration.right.dist_coeffs,
       calibration.R2, calibration.P2,
-      img_size, CV_16SC2,
+      img_size, CV_32FC1,
       rectification_map_right_x, rectification_map_right_y );
+
+    cv::Mat original_grid( img_size.height * img_size.width, 1, CV_32FC2 );
+    for( int y = 0; y < img_size.height; y++ )
+    {
+      for( int x = 0; x < img_size.width; x++ )
+      {
+        original_grid.at< cv::Vec2f >( y * img_size.width + x, 0 ) = cv::Vec2f( x, y );
+      }
+    }
+
+    cv::Mat rectified_grid;
+    cv::undistortPoints( original_grid, rectified_grid,
+                         calibration.left.camera_matrix,
+                         calibration.left.dist_coeffs,
+                         calibration.R1,
+                         calibration.P1 );
+
+    rectified_grid = rectified_grid.reshape( 2, img_size.height );
+
+    cv::Mat maps[2];
+    cv::split( rectified_grid, maps );
+    unrectification_map_x = maps[0];
+    unrectification_map_y = maps[1];
 
     rectification_computed = true;
   }
@@ -206,20 +232,6 @@ compute_stereo_disparity
   config->set_value( "speckle_range", d->speckle_range,
     "Maximum disparity variation within each connected component for speckle filtering." );
 
-  config->set_value( "output_format", d->output_format,
-    "Output disparity format: "
-    "'raw' (CV_16S with disparity * 16, OpenCV native), "
-    "'float32' (CV_32F with disparity in pixels), "
-    "'uint16_scaled' (CV_16U with disparity * 256, compatible with external algorithms)." );
-
-  config->set_value( "disparity_as_alpha", d->disparity_as_alpha,
-    "If true, returns the rectified left image with disparity as the alpha (4th) channel. "
-    "The output will be a 4-channel BGRA image where the alpha channel contains the 8-bit disparity." );
-
-  config->set_value( "invert_disparity_alpha", d->invert_disparity_alpha,
-    "If true and disparity_as_alpha is enabled, inverts the disparity values in the alpha channel. "
-    "Invalid (zero) disparity pixels are set to white before inversion." );
-
   config->set_value( "use_wls_filter", d->use_wls_filter,
     "Apply Weighted Least Squares (WLS) filtering to smooth the disparity map while "
     "preserving edges. Requires computing disparity for both left and right images." );
@@ -234,6 +246,25 @@ compute_stereo_disparity
     "Path to stereo calibration file (OpenCV YAML/XML format). If specified, images will be "
     "rectified before computing disparity. Leave empty if input images are already rectified "
     "(e.g., when called from measurement_utilities which handles its own rectification)." );
+
+  config->set_value( "compute_depth", d->compute_depth,
+  "If true, computes depth Z = (fx * baseline) / disparity. "
+  "If false, computes disparity. Depth requires a valid calibration file." );
+
+  config->set_value( "export_as_alpha", d->export_as_alpha,
+    "If true, outputs the original left color image with the computed map (depth/disparity) "
+    "in the 4th (Alpha) channel. If false, outputs a 1-channel image of the map." );
+
+  config->set_value( "output_rectified", d->output_rectified,
+    "If true, the output map (and color image if export_as_alpha is true) will be kept "
+    "in the rectified coordinate space. If false, they will be mapped back to the original image." );
+
+  config->set_value( "output_format", d->output_format,
+    "Output format: 'float32' (best for TIFF), 'uint16_scaled' (best for 16-bit PNG), or 'raw'." );
+
+  config->set_value( "uint16_scale_factor", d->uint16_scale_factor,
+    "Multiplier used ONLY when output_format is 'uint16_scaled'. "
+    "e.g., if depth is in meters, a factor of 1000 converts it to millimeters to save as integers in PNG." );
 
   return config;
 }
@@ -252,13 +283,15 @@ void compute_stereo_disparity
   d->block_size = config->get_value< int >( "block_size" );
   d->speckle_window_size = config->get_value< int >( "speckle_window_size" );
   d->speckle_range = config->get_value< int >( "speckle_range" );
-  d->output_format = config->get_value< std::string >( "output_format" );
-  d->disparity_as_alpha = config->get_value< bool >( "disparity_as_alpha" );
-  d->invert_disparity_alpha = config->get_value< bool >( "invert_disparity_alpha" );
   d->use_wls_filter = config->get_value< bool >( "use_wls_filter" );
   d->wls_lambda = config->get_value< double >( "wls_lambda" );
   d->wls_sigma = config->get_value< double >( "wls_sigma" );
   d->calibration_file = config->get_value< std::string >( "calibration_file" );
+  d->compute_depth = config->get_value< bool >( "compute_depth" );
+  d->export_as_alpha = config->get_value< bool >( "export_as_alpha" );
+  d->output_rectified = config->get_value< bool >( "output_rectified" );
+  d->output_format = config->get_value< std::string >( "output_format" );
+  d->uint16_scale_factor = config->get_value< double >( "uint16_scale_factor" );
 
   // Ensure num_disparities is divisible by 16
   if( d->num_disparities % 16 != 0 )
@@ -335,7 +368,7 @@ kv::image_container_sptr compute_stereo_disparity
 
   // Rectify if calibration is loaded
   cv::Mat left_rect, right_rect;
-  cv::Mat left_color_rect;  // For disparity_as_alpha mode
+  cv::Mat left_color_rect;  // For export_as_alpha mode
   if( d->rectify_images )
   {
     d->compute_rectification_maps( left_gray.size() );
@@ -345,7 +378,7 @@ kv::image_container_sptr compute_stereo_disparity
                d->rectification_map_right_y, cv::INTER_LINEAR );
 
     // Also rectify color image if we need it for alpha channel output
-    if( d->disparity_as_alpha )
+    if( d->export_as_alpha )
     {
       cv::remap( ocv_left, left_color_rect, d->rectification_map_left_x,
                  d->rectification_map_left_y, cv::INTER_LINEAR );
@@ -355,105 +388,117 @@ kv::image_container_sptr compute_stereo_disparity
   {
     left_rect = left_gray;
     right_rect = right_gray;
-    if( d->disparity_as_alpha )
+    if( d->export_as_alpha )
     {
       left_color_rect = ocv_left;
     }
   }
 
-  // Compute disparity
-  cv::Mat left_disparity;
-  d->left_matcher->compute( left_rect, right_rect, left_disparity );
+  cv::Mat left_disparity_raw;
+  d->left_matcher->compute( left_rect, right_rect, left_disparity_raw );
 
-  // Apply WLS filter if enabled
   if( d->use_wls_filter && d->right_matcher && d->wls_filter )
   {
-    cv::Mat right_disparity, filtered_disparity;
-    d->right_matcher->compute( right_rect, left_rect, right_disparity );
-    d->wls_filter->filter( left_disparity, left_rect, filtered_disparity,
-                           right_disparity, cv::Rect(), right_rect );
-    left_disparity = filtered_disparity;
+    cv::Mat right_disparity_raw, filtered_disparity;
+    d->right_matcher->compute( right_rect, left_rect, right_disparity_raw );
+
+    d->wls_filter->filter( left_disparity_raw, left_rect, filtered_disparity,
+                           right_disparity_raw, cv::Rect(), right_rect );
+
+    left_disparity_raw = filtered_disparity;
   }
 
-  // Convert to requested output format
+  cv::Mat float_map;
+  left_disparity_raw.convertTo( float_map, CV_32F, 1.0 / 16.0 );
+  float_map.setTo( 0, float_map < 0 );
+
+  if( d->compute_depth )
+  {
+    if( d->calibration.P1.empty() ) {
+      VITAL_THROW( kv::invalid_data, "Cannot compute depth: calibration data missing." );
+    }
+
+    double fx = d->calibration.P1.at<double>( 0, 0 );
+    double baseline = -d->calibration.P2.at<double>( 0, 3 ) / d->calibration.P2.at<double>( 0, 0 );
+    double depth_scale = fx * baseline;
+
+    cv::Mat depth_map = cv::Mat::zeros( float_map.size(), CV_32F );
+    cv::Mat mask = float_map > 0;
+    cv::divide( depth_scale, float_map, depth_map );
+    depth_map.setTo( 0, ~mask );
+
+    float_map = depth_map;
+  }
+
+  cv::Mat aligned_map;
+  if( d->rectify_images && !d->output_rectified )
+  {
+    cv::remap( float_map, aligned_map,
+               d->unrectification_map_x, d->unrectification_map_y,
+               cv::INTER_NEAREST, cv::BORDER_CONSTANT, cv::Scalar( 0 ) );
+  }
+  else
+  {
+    aligned_map = float_map;
+  }
+
+  cv::Mat formatted_map;
+  if( d->output_format == "float32" )
+  {
+    formatted_map = aligned_map;
+  }
+  else if( d->output_format == "uint16_scaled" )
+  {
+    aligned_map.convertTo( formatted_map, CV_16U, d->uint16_scale_factor );
+  }
+  else // "raw"
+  {
+    if( d->compute_depth ) formatted_map = aligned_map;
+    else {
+      aligned_map.convertTo( formatted_map, CV_16S, 16.0 );
+    }
+  }
+  
   cv::Mat output;
-  if( d->output_format == "raw" )
+  if( d->export_as_alpha )
   {
-    // Raw OpenCV format: CV_16S with disparity * 16
-    output = left_disparity;
-  }
-  else if( d->output_format == "float32" )
-  {
-    // Float format: CV_32F with disparity in pixels
-    left_disparity.convertTo( output, CV_32F, 1.0 / 16.0 );
-  }
-  else // uint16_scaled
-  {
-    // Scaled uint16: CV_16U with disparity * 256
-    // Convert from fixed-point (*16) to scaled (*256) = multiply by 16
-    cv::Mat float_disp;
-    left_disparity.convertTo( float_disp, CV_32F, 1.0 / 16.0 );
-
-    // Clamp negative values and scale
-    cv::Mat scaled;
-    float_disp.setTo( 0, float_disp < 0 );
-    float_disp.convertTo( scaled, CV_32F, 256.0 );
-    scaled.setTo( 65535, scaled > 65535 );
-    scaled.convertTo( output, CV_16U );
-  }
-
-  // If disparity_as_alpha is enabled, combine with left color image
-  if( d->disparity_as_alpha && !left_color_rect.empty() )
-  {
-    // Convert left image to BGRA
-    cv::Mat left_bgra;
-    if( left_color_rect.channels() == 1 )
-    {
-      cv::cvtColor( left_color_rect, left_bgra, cv::COLOR_GRAY2BGRA );
-    }
-    else if( left_color_rect.channels() == 3 )
-    {
-      cv::cvtColor( left_color_rect, left_bgra, cv::COLOR_BGR2BGRA );
-    }
-    else if( left_color_rect.channels() == 4 )
-    {
-      left_bgra = left_color_rect;
-    }
-    else
-    {
-      LOG_WARN( d->logger, "Unexpected number of channels in left image" );
-      left_bgra = left_color_rect;
+    cv::Mat color_base;
+    if( d->rectify_images && d->output_rectified ) {
+      color_base = left_color_rect;
+    } else {
+      color_base = ocv_left;
     }
 
-    // Convert disparity to 8-bit for alpha channel
-    cv::Mat disp_8bit;
-    cv::Mat float_disp;
-    left_disparity.convertTo( float_disp, CV_32F, 1.0 / 16.0 );
-    float_disp.setTo( 0, float_disp < 0 );
-    float_disp.convertTo( disp_8bit, CV_8U );
-
-    // Invert if requested
-    if( d->invert_disparity_alpha )
-    {
-      // Set zero (invalid) pixels to white before inversion
-      cv::Mat mask;
-      cv::inRange( disp_8bit, cv::Scalar( 0 ), cv::Scalar( 0 ), mask );
-      disp_8bit.setTo( cv::Scalar( 255 ), mask );
-
-      // Invert
-      cv::bitwise_not( disp_8bit, disp_8bit );
+    cv::Mat color_converted;
+    if( formatted_map.depth() == CV_32F ) {
+      color_base.convertTo( color_converted, CV_32F, 1.0/255.0 );
+    }
+    else if( formatted_map.depth() == CV_16U ) {
+      color_base.convertTo( color_converted, CV_16U, 257.0 );
+    }
+    else {
+      color_base.convertTo( color_converted, formatted_map.depth() );
     }
 
-    // Set disparity as alpha channel
-    std::vector<cv::Mat> channels( 4 );
-    cv::split( left_bgra, channels );
-    channels[3] = disp_8bit;
+    cv::cvtColor( color_converted, output, cv::COLOR_BGR2BGRA );
+    std::vector<cv::Mat> channels;
+    cv::split( output, channels );
+    channels[3] = formatted_map;
     cv::merge( channels, output );
+  }
+  else
+  {
+    output = formatted_map;
+  }
+
+  if (output.channels() == 1)
+  {
+    return kv::image_container_sptr(
+      new kwiver::arrows::ocv::image_container( output, kwiver::arrows::ocv::image_container::OTHER_COLOR ) );
   }
 
   return kv::image_container_sptr(
-    new kwiver::arrows::ocv::image_container(
-      output, kwiver::arrows::ocv::image_container::BGR_COLOR ) );
+    new kwiver::arrows::ocv::image_container( output, kwiver::arrows::ocv::image_container::BGR_COLOR ) );
 }
 
 } //end namespace viame

--- a/plugins/opencv/compute_stereo_disparity.cxx
+++ b/plugins/opencv/compute_stereo_disparity.cxx
@@ -56,8 +56,10 @@ public:
   mutable cv::Mat rectification_map_right_x;
   mutable cv::Mat rectification_map_right_y;
 
-  // Calibration data (loaded if calibration_file is set)
-  calibrate_stereo_cameras_result calibration;
+  // Calibration data (loaded if calibration_file is set). Mutable because
+  // single-file formats carry no rectification transforms, so those are filled
+  // in lazily once the first image gives us an image size.
+  mutable calibrate_stereo_cameras_result calibration;
   calibrate_stereo_cameras calibrator;
 
   // Stereo matchers
@@ -117,7 +119,7 @@ public:
       return;
     }
 
-    if( !calibrator.load_calibration_opencv( calibration_file, calibration ) )
+    if( !calibrator.load_calibration( calibration_file, calibration ) )
     {
       VITAL_THROW( kv::invalid_data,
         "Failed to load calibration from: " + calibration_file );
@@ -131,6 +133,14 @@ public:
     if( rectification_computed )
     {
       return;
+    }
+
+    if( !calibrate_stereo_cameras::ensure_rectification( calibration, img_size ) )
+    {
+      VITAL_THROW( kv::invalid_data,
+        "Calibration lacks the rectification transforms needed for " +
+        std::to_string( img_size.width ) + "x" +
+        std::to_string( img_size.height ) + " images: " + calibration_file );
     }
 
     cv::initUndistortRectifyMap(

--- a/plugins/opencv/pair_stereo_detections.cxx
+++ b/plugins/opencv/pair_stereo_detections.cxx
@@ -1,4 +1,5 @@
 #include "pair_stereo_detections.h"
+#include "calibrate_stereo_cameras.h"
 
 #include <arrows/ocv/image_container.h>
 
@@ -10,51 +11,24 @@ void
 viame::pair_stereo_detections
 ::load_camera_calibration()
 {
-  try
-  {
-    auto intrinsics_path = m_cameras_directory + "/intrinsics.yml";
-    auto extrinsics_path = m_cameras_directory + "/extrinsics.yml";
-    auto fs = cv::FileStorage( intrinsics_path, cv::FileStorage::Mode::READ );
+  calibrate_stereo_cameras calibrator;
+  calibrate_stereo_cameras_result result;
 
-    // load left camera intrinsic parameters
-    if( !fs.isOpened() )
-    {
-      VITAL_THROW( kwiver::vital::file_not_found_exception, intrinsics_path,
-                   "could not locate file in path" );
-    }
-
-    fs["M1"] >> m_K1;
-    fs["D1"] >> m_D1;
-    fs["M2"] >> m_K2;
-    fs["D2"] >> m_D2;
-    fs.release();
-
-    // load extrinsic parameters
-    fs = cv::FileStorage( extrinsics_path, cv::FileStorage::Mode::READ );
-    if( !fs.isOpened() )
-    {
-      VITAL_THROW( kwiver::vital::file_not_found_exception, extrinsics_path,
-                   "could not locate file in path" );
-    }
-
-    fs["Q"] >> m_Q;
-    fs["R1"] >> m_R1;
-    fs["P1"] >> m_P1;
-    fs["R2"] >> m_R2;
-    fs["P2"] >> m_P2;
-    fs["R"] >> m_R;
-    fs["T"] >> m_T;
-
-    // Compute RVec from matrix for later use
-    cv::Rodrigues( m_R, m_Rvec );
-
-    fs.release();
-  }
-  catch( const kwiver::vital::file_not_found_exception& e )
+  if( !calibrator.load_calibration( m_calibration_file, result ) )
   {
     VITAL_THROW( kwiver::vital::invalid_data,
-                 "Calibration file not found : " + std::string( e.what() ) );
+                 "Could not read calibration : " + m_calibration_file );
   }
+
+  m_K1 = result.left.camera_matrix;
+  m_D1 = result.left.dist_coeffs;
+  m_K2 = result.right.camera_matrix;
+  m_D2 = result.right.dist_coeffs;
+  m_R = result.R;
+  m_T = result.T;
+
+  // Compute RVec from matrix for later use
+  cv::Rodrigues( m_R, m_Rvec );
 }
 
 float
@@ -561,9 +535,45 @@ cv::Mat
 viame::pair_stereo_detections
 ::reproject_3d_depth_map( const cv::Mat& cv_disparity_left ) const
 {
+  // Every path that consumes the rectification transforms runs through here
+  // first, so this is where a single-file calibration gets them derived.
+  ensure_rectification( cv_disparity_left.size() );
+
   cv::Mat cv_pos_3d_left_map;
   cv::reprojectImageTo3D( cv_disparity_left, cv_pos_3d_left_map, m_Q, false );
   return cv_pos_3d_left_map;
+}
+
+
+void
+viame::pair_stereo_detections
+::ensure_rectification( const cv::Size& image_size ) const
+{
+  if( !m_R1.empty() && !m_P1.empty() && !m_Q.empty() )
+  {
+    return;
+  }
+
+  calibrate_stereo_cameras_result result;
+  result.left.camera_matrix = m_K1;
+  result.left.dist_coeffs = m_D1;
+  result.right.camera_matrix = m_K2;
+  result.right.dist_coeffs = m_D2;
+  result.R = m_R;
+  result.T = m_T;
+
+  if( !calibrate_stereo_cameras::ensure_rectification( result, image_size ) )
+  {
+    VITAL_THROW( kwiver::vital::invalid_data,
+                 "Could not derive rectification transforms from calibration : " +
+                 m_calibration_file );
+  }
+
+  m_R1 = result.R1;
+  m_R2 = result.R2;
+  m_P1 = result.P1;
+  m_P2 = result.P2;
+  m_Q = result.Q;
 }
 
 

--- a/plugins/opencv/pair_stereo_detections.h
+++ b/plugins/opencv/pair_stereo_detections.h
@@ -38,19 +38,27 @@ public:
   pair_stereo_detections() = default;
 
   // Configuration settings
-  std::string m_cameras_directory;
+  std::string m_calibration_file;
   float m_iou_pair_threshold{ 0.1f };
   std::string m_pairing_method{ "PAIRING_3D" };
   bool m_verbose{}; // Set to true to activate debug print
 
-  // Camera depth information
-  cv::Mat m_Q, m_K1, m_D1, m_R1, m_P1, m_K2, m_D2, m_R2, m_P2, m_R, m_Rvec, m_T;
+  // Camera depth information. The rectification transforms are mutable because
+  // single-file calibrations do not store them; they are derived on first use,
+  // when an image size is finally available.
+  cv::Mat m_K1, m_D1, m_K2, m_D2, m_R, m_Rvec, m_T;
+  mutable cv::Mat m_Q, m_R1, m_P1, m_R2, m_P2;
 
   /// @brief Project depth map as 3 channel 3D image
   cv::Mat reproject_3d_depth_map( const cv::Mat& cv_disparity_left ) const;
 
-  /// @brief Load matrix calibration from settings camera directory
+  /// @brief Load matrix calibration from the configured calibration file
   void load_camera_calibration();
+
+  /// @brief Derive the rectification transforms if the calibration lacked them
+  /// No-op once they are populated. Called for the first disparity map, which
+  /// is the earliest point an image size is known.
+  void ensure_rectification( const cv::Size& image_size ) const;
 
   /// @brief Compute median of input vector of values. Returns 0 if empty.
   static float compute_median( std::vector< float > values, bool is_sorted = false );

--- a/plugins/opencv/pair_stereo_detections_process.cxx
+++ b/plugins/opencv/pair_stereo_detections_process.cxx
@@ -22,8 +22,9 @@ namespace kv = kwiver::vital;
 
 namespace viame {
 
-create_config_trait( cameras_directory, std::string, "",
-  "The calibrated cameras files directory" )
+create_config_trait( calibration_file, std::string, "",
+  "Stereo calibration file (.json, .yml, .npz or .mat), or a directory of "
+  "OpenCV intrinsics.yml / extrinsics.yml" )
 create_config_trait( pairing_method, std::string, "PAIRING_3D",
   "One of PAIRING_3D, PAIRING_IOU, PAIRING_RECTIFIED_IOU" )
 create_config_trait( iou_pair_threshold, double, "0.1",
@@ -78,7 +79,7 @@ void
 pair_stereo_detections_process
 ::make_config()
 {
-  declare_config_using_trait( cameras_directory );
+  declare_config_using_trait( calibration_file );
   declare_config_using_trait( pairing_method );
   declare_config_using_trait( iou_pair_threshold );
   declare_config_using_trait( verbose );
@@ -89,7 +90,7 @@ void
 pair_stereo_detections_process
 ::_configure()
 {
-  d->m_cameras_directory = config_value_using_trait( cameras_directory );
+  d->m_calibration_file = config_value_using_trait( calibration_file );
   d->m_pairing_method = config_value_using_trait( pairing_method );
   d->m_iou_pair_threshold = config_value_using_trait( iou_pair_threshold );
   d->m_verbose = config_value_using_trait( verbose );

--- a/plugins/opencv/pair_stereo_tracks.cxx
+++ b/plugins/opencv/pair_stereo_tracks.cxx
@@ -12,7 +12,7 @@ void
 viame::pair_stereo_tracks
 ::load_camera_calibration()
 {
-  m_detection_pairing->m_cameras_directory = m_cameras_directory;
+  m_detection_pairing->m_calibration_file = m_calibration_file;
   m_detection_pairing->load_camera_calibration();
 }
 

--- a/plugins/opencv/pair_stereo_tracks.h
+++ b/plugins/opencv/pair_stereo_tracks.h
@@ -44,7 +44,7 @@ public:
   pair_stereo_tracks();
 
   // Configuration settings
-  std::string m_cameras_directory;
+  std::string m_calibration_file;
   kwiver::vital::logger_handle_t m_logger;
   float m_iou_pair_threshold{ 0.1f };
   int m_min_detection_number_threshold{ 0 };
@@ -63,7 +63,7 @@ public:
   std::map< size_t, Pairing > m_left_to_right_pairing;
 
 
-  /// @brief Load matrix calibration from settings camera directory
+  /// @brief Load matrix calibration from the configured calibration file
   void load_camera_calibration();
 
   /// @brief Update 3D tracks positions given a list of tracks and tracks disparity map

--- a/plugins/opencv/pair_stereo_tracks_process.cxx
+++ b/plugins/opencv/pair_stereo_tracks_process.cxx
@@ -27,8 +27,9 @@ namespace kv = kwiver::vital;
 
 namespace viame {
 
-create_config_trait( cameras_directory, std::string, "",
-  "The calibrated cameras files directory" )
+create_config_trait( calibration_file, std::string, "",
+  "Stereo calibration file (.json, .yml, .npz or .mat), or a directory of "
+  "OpenCV intrinsics.yml / extrinsics.yml" )
 create_config_trait( pairing_method, std::string, "PAIRING_3D",
   "One of PAIRING_3D, PAIRING_IOU, PAIRING_RECTIFIED_IOU" )
 create_config_trait( min_detection_number_threshold, int, "0",
@@ -100,7 +101,7 @@ void
 pair_stereo_tracks_process
 ::make_config()
 {
-  declare_config_using_trait( cameras_directory );
+  declare_config_using_trait( calibration_file );
   declare_config_using_trait( min_detection_number_threshold );
   declare_config_using_trait( max_detection_number_threshold );
   declare_config_using_trait( min_detection_surface_threshold_pix );
@@ -117,7 +118,7 @@ void
 pair_stereo_tracks_process
 ::_configure()
 {
-  d->m_cameras_directory = config_value_using_trait( cameras_directory );
+  d->m_calibration_file = config_value_using_trait( calibration_file );
   d->m_min_detection_number_threshold = config_value_using_trait( min_detection_number_threshold );
   d->m_max_detection_number_threshold = config_value_using_trait( max_detection_number_threshold );
   d->m_min_detection_surface_threshold_pix = config_value_using_trait( min_detection_surface_threshold_pix );


### PR DESCRIPTION
### Problem

The measurement and ifremer stereo pipes pointed their calibration at a `global:input_cameras_directory` defaulting to `/home/<user>/Desktop/...`, exposed as a DIVE folder picker.

That picker was a no-op. `$CONFIG{}` expands at parse time with backward references only, while `-s` blocks are appended last, so overriding the global never reached the consuming process — runs silently used the hardcoded path.

### Changes

- Name the consuming process keys directly and declare them in a `# Calibration Keys:` header (needs Kitware/dive#1814)
- Route `ocv_stereo_disparity` and the ifremer `ocv_pair_stereo_*` processes through `read_stereo_rig`, which already handles both files and OpenCV directories, so they accept `.json`/`.yml`/`.npz`/`.mat` — DIVE hands down a single file, but these only ever read a directory of `intrinsics.yml` + `extrinsics.yml`
- Rename their `cameras_directory` config to `calibration_file`, matching every other camera file parameter
- Those formats carry no rectification transforms, so `stereoRectify` now derives them on the first frame, where an image size is finally known
- Image-producing pipes default their output directory to `.`

### Verification

- `kwiver pipe-config` confirms `-s` now reaches `depth_map:computer:ocv_stereo_disparity:calibration_file`, and that the output template bakes to `./depth_map%06d.png`
- `viame_opencv` and `viame_processes_opencv` build and link clean
- DIVE's discovery resolves the expected keys for all six calibration-requiring pipes

### Note

`calibration_params.conf` still has `/home/<user>/...` paths for `video_filename` / `tracks_left|right` — those are example *inputs* DIVE overrides per-run, left as documentation.