### PR TITLE
Rewrite pipeline Title/Description headers for DIVE

### DIFF
--- a/configs/add-ons/align-cameras/utility_align_cameras_2-cam.pipe
+++ b/configs/add-ons/align-cameras/utility_align_cameras_2-cam.pipe
@@ -1,10 +1,7 @@
 # =============================================================================
 # Title: Align Cameras (2-Camera)
 #
-# Description: Registers a two-camera rig by matching many image pairs with
-# the MINIMA-LoFTR cross-spectral matcher and pooling one homography over
-# every contributing frame. Writes a DIVE camera registration JSON
-# (format v2) with per-frame observations and quality statistics.
+# Description: Registers a two-camera rig and writes a camera registration JSON.
 # =============================================================================
 
 config _scheduler

--- a/configs/add-ons/align-cameras/utility_align_cameras_3-cam.pipe
+++ b/configs/add-ons/align-cameras/utility_align_cameras_3-cam.pipe
@@ -1,13 +1,8 @@
 # =============================================================================
 # Title: Align Cameras (3-Camera)
 #
-# Description: Registers a three-camera rig in one job by matching many image
-# pairs with the MINIMA-LoFTR cross-spectral matcher and pooling one
-# homography per camera pair over every contributing frame, sharing one model
-# load and one pass over the selected frames. With all three pairs solved a
-# loop-closure residual reports whether the triplet is mutually consistent.
-# Writes a DIVE camera registration JSON (format v2) with per-frame
-# observations and quality statistics.
+# Description: Registers a three-camera rig and writes a camera registration
+# JSON.
 # =============================================================================
 
 config _scheduler

--- a/configs/add-ons/arctic-seal/common_arctic_seal_eo_tf_detector.pipe
+++ b/configs/add-ons/arctic-seal/common_arctic_seal_eo_tf_detector.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Optical seal detector file
+# Title: Arctic Seal EO TensorFlow Detector
 #
-# Description: Optical seal detector file
+# Description: TensorFlow seal detector for optical imagery, shared by the
+# arctic seal pipelines.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/common_arctic_seal_eo_tiny_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/common_arctic_seal_eo_tiny_yolo_detector.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Threaded seal detector file
+# Title: Arctic Seal EO Tiny YOLO Detector
 #
-# Description: Shared detector configuration that can be included by other
-# pipelines. Uses model: arctic_seal_eo_tiny.weights. Uses YOLO-based
-# detection.
+# Description: Lightweight YOLO seal detector for optical imagery, run as two
+# alternating-frame instances whose outputs are merged.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/common_arctic_seal_eo_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/common_arctic_seal_eo_yolo_detector.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Threaded seal detector file
+# Title: Arctic Seal EO YOLO Detector
 #
-# Description: Shared detector configuration that can be included by other
-# pipelines. Uses model: arctic_seal_eo.weights. Uses YOLO-based detection.
+# Description: YOLO seal detector for optical imagery, run as two
+# alternating-frame instances whose outputs are merged.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/common_arctic_seal_ir_tf_detector.pipe
+++ b/configs/add-ons/arctic-seal/common_arctic_seal_ir_tf_detector.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Thermal seal detector file
+# Title: Arctic Seal IR TensorFlow Detector
 #
-# Description: Thermal seal detector file
+# Description: TensorFlow hotspot detector for thermal imagery with fixed-range
+# normalization.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/common_arctic_seal_ir_tiny_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/common_arctic_seal_ir_tiny_yolo_detector.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Threaded seal detector file
+# Title: Arctic Seal IR Tiny YOLO Detector
 #
-# Description: Shared detector configuration that can be included by other
-# pipelines. Uses model: arctic_seal_ir_tiny.weights. Uses YOLO-based
-# detection.
+# Description: Percentile-normalized thermal imagery fed to a lightweight YOLO
+# hotspot detector, run as two alternating-frame instances.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/common_arctic_seal_ir_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/common_arctic_seal_ir_yolo_detector.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Threaded seal detector file
+# Title: Arctic Seal IR YOLO Detector
 #
-# Description: Shared detector configuration that can be included by other
-# pipelines. Uses model: arctic_seal_ir.weights. Uses YOLO-based detection.
+# Description: Percentile-normalized thermal imagery fed to a YOLO hotspot
+# detector, run as two alternating-frame instances.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/detector_arctic_seal_eo_tf.pipe
+++ b/configs/add-ons/arctic-seal/detector_arctic_seal_eo_tf.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Detector - Arctic Seal EO TF
+# Title: Arctic Seal EO TensorFlow Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses arctic
-# seal eo tf detector configuration. Outputs results to eo_detections%06d.jpg.
+# Description: TensorFlow seal detector on optical imagery.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/detector_arctic_seal_eo_yolo.pipe
+++ b/configs/add-ons/arctic-seal/detector_arctic_seal_eo_yolo.pipe
@@ -1,9 +1,7 @@
 # =============================================================================
-# Title: Detector - Arctic Seal EO YOLO
+# Title: Arctic Seal EO YOLO Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses arctic
-# seal eo yolo detector configuration. Outputs results to
-# eo_detections%06d.jpg.
+# Description: YOLO seal detector on optical imagery.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/detector_arctic_seal_fusion_yolo.pipe
+++ b/configs/add-ons/arctic-seal/detector_arctic_seal_fusion_yolo.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Run detectors on unsynchronous co-collected optical and thermal imagery
+# Title: Arctic Seal Fusion YOLO Detector
 #
-# Description: Run detectors on unsynchronous co-collected optical and thermal
-# imagery Outputs to output_result%06d.jpg.
+# Description: Time-aligns unsynchronized optical and thermal imagery, detects
+# hotspots in thermal frames and runs the optical detector only on frames with a
+# thermal hit. Writes annotated images rather than a detection file.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/detector_arctic_seal_ir_tf.pipe
+++ b/configs/add-ons/arctic-seal/detector_arctic_seal_ir_tf.pipe
@@ -1,9 +1,7 @@
 # =============================================================================
-# Title: Detector - Arctic Seal IR TF
+# Title: Arctic Seal IR TensorFlow Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses arctic
-# seal ir tf detector configuration. Outputs results to
-# ir_out_images/frame%06d.jpg.
+# Description: TensorFlow hotspot detector on thermal imagery.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/detector_arctic_seal_ir_yolo.pipe
+++ b/configs/add-ons/arctic-seal/detector_arctic_seal_ir_yolo.pipe
@@ -1,9 +1,7 @@
 # =============================================================================
-# Title: Detector - Arctic Seal IR YOLO
+# Title: Arctic Seal IR YOLO Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses arctic
-# seal ir yolo detector configuration. Outputs results to
-# ir_out_images/frame%06d.jpg.
+# Description: YOLO hotspot detector on thermal imagery.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/arctic-seal/detector_arctic_seal_yolo_2-cam.pipe
+++ b/configs/add-ons/arctic-seal/detector_arctic_seal_yolo_2-cam.pipe
@@ -1,5 +1,5 @@
 # =============================================================================
-# Title: Detector - Arctic Seal YOLO 2-cam
+# Title: Arctic Seal YOLO Two-Camera Detector
 #
 # Description: Dual camera arctic seal detector for synchronized optical and
 # thermal imagery. The thermal detector triggers subregion detection on the

--- a/configs/add-ons/arctic-seal/detector_arctic_seal_yolo_3-cam.pipe
+++ b/configs/add-ons/arctic-seal/detector_arctic_seal_yolo_3-cam.pipe
@@ -1,5 +1,5 @@
 # =============================================================================
-# Title: Detector - Arctic Seal YOLO 3-cam
+# Title: Arctic Seal YOLO Three-Camera Detector
 #
 # Description: Three camera arctic seal detector for synchronized optical,
 # thermal, and ultraviolet imagery. The thermal detector triggers subregion

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tf_eo_only.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tf_eo_only.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal TF EO Only
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# TensorFlow-based models.
+# Description: TensorFlow seal detector on the optical stream only; the thermal
+# stream is ignored.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tf_ir_only.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tf_ir_only.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal TF IR Only
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# TensorFlow-based models.
+# Description: TensorFlow hotspot detector on the thermal stream only; the
+# optical stream is ignored.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tf_ir_to_eo_frame_trigger.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tf_ir_to_eo_frame_trigger.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal TF IR To EO Frame Trigger
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# TensorFlow-based models.
+# Description: TensorFlow hotspot detector on every thermal frame; the optical
+# detector runs only on frames whose thermal pair had a hit.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tiny_yolo_eo_only.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tiny_yolo_eo_only.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal Tiny YOLO EO Only
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Tiny darknet seal detector (four alternating-frame instances,
+# NMS-merged) on the optical stream only.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tiny_yolo_eo_tracker.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tiny_yolo_eo_tracker.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Arctic Seal Tiny YOLO EO Tracker
+# Title: Arctic Seal Tiny YOLO EO Stabilized Tracker
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Tiny darknet seal detector on the optical stream, linked by a
+# homography-stabilized IoU tracker.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tiny_yolo_eo_tracker_alt.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_tiny_yolo_eo_tracker_alt.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Arctic Seal Tiny YOLO EO Tracker Alt
+# Title: Arctic Seal Tiny YOLO EO Appearance Tracker
 #
-# Description: Runs object tracking on detected objects across video frames.
-# Configured for arctic seal aerial survey imagery. Uses YOLO-based detection.
+# Description: Tiny darknet seal detector on the optical stream, linked into
+# tracks by ResNet50 appearance association.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_eo_ir_early_fusion.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_eo_ir_early_fusion.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal YOLO EO IR Early Fusion
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Warps each thermal frame onto its optical frame, merges the two
+# into one image and runs the fusion darknet detector on it.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_eo_only.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_eo_only.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal YOLO EO Only
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Darknet seal detector (two alternating-frame instances,
+# NMS-merged) on the optical stream only.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_ir_only.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_ir_only.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal YOLO IR Only
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Tiny darknet hotspot detector on the thermal stream only; the
+# optical stream is ignored.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_ir_to_eo_frame_trigger.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_ir_to_eo_frame_trigger.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal YOLO IR To EO Frame Trigger
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Tiny darknet hotspot detector on every thermal frame; the optical
+# detector runs only on frames whose thermal pair had a hit.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_ir_to_eo_region_trigger.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_ir_to_eo_region_trigger.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal YOLO IR To EO Region Trigger
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Thermal hotspots are warped onto the optical frame and the
+# optical detector runs only in 640 px windows around them.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_ir_to_tiny_eo_region_tigger.pipe
+++ b/configs/add-ons/arctic-seal/embedded_dual_stream/arctic_seal_yolo_ir_to_tiny_eo_region_tigger.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Arctic Seal YOLO IR To Tiny EO Region Tigger
+# Title: Arctic Seal YOLO IR To Tiny EO Region Trigger
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Thermal hotspots are warped onto the optical frame and the tiny
+# optical detector runs only in 640 px windows around them.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tf_detector.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tf_detector.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal EO TF Detector
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# TensorFlow-based models.
+# Description: Embedded TensorFlow seal detector; detections are emitted as
+# single-frame tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tiny_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tiny_yolo_detector.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal EO Tiny YOLO Detector
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Embedded tiny darknet seal detector; detections are emitted as
+# single-frame tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tiny_yolo_tracker.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tiny_yolo_tracker.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Arctic Seal EO Tiny YOLO Tracker
+# Title: Arctic Seal EO Tiny YOLO Stabilized Tracker
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Embedded tiny darknet seal detector followed by a
+# homography-stabilized IoU tracker.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tiny_yolo_tracker_alt2.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tiny_yolo_tracker_alt2.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Arctic Seal EO Tiny YOLO Tracker Alt2
+# Title: Arctic Seal EO Tiny YOLO Appearance Tracker
 #
-# Description: Runs object tracking on detected objects across video frames.
-# Configured for arctic seal aerial survey imagery. Uses YOLO-based detection.
+# Description: Embedded tiny darknet seal detector followed by ResNet50
+# appearance track association.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tiny_yolo_tracker_alt3.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_tiny_yolo_tracker_alt3.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Arctic Seal EO Tiny YOLO Tracker Alt3
+# Title: Arctic Seal EO Tiny YOLO ByteTrack Tracker
 #
-# Description: Runs object tracking on detected objects across video frames.
-# Configured for arctic seal aerial survey imagery. Uses YOLO-based detection.
+# Description: Embedded tiny darknet seal detector followed by the default
+# ByteTrack tracker.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_eo_yolo_detector.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal EO YOLO Detector
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Embedded darknet seal detector; detections are emitted as
+# single-frame tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_ir_tf_detector.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_ir_tf_detector.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal IR TF Detector
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# TensorFlow-based models.
+# Description: Embedded TensorFlow hotspot detector; detections are emitted as
+# single-frame tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_ir_tiny_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_ir_tiny_yolo_detector.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal IR Tiny YOLO Detector
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Embedded tiny darknet hotspot detector; detections are emitted as
+# single-frame tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_ir_yolo_detector.pipe
+++ b/configs/add-ons/arctic-seal/embedded_single_stream/arctic_seal_ir_yolo_detector.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Arctic Seal IR YOLO Detector
 #
-# Description: Configured for arctic seal aerial survey imagery. Uses
-# YOLO-based detection.
+# Description: Embedded darknet hotspot detector; detections are emitted as
+# single-frame tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/community-fish/detector_community_fish_rf_detr_medium.pipe
+++ b/configs/add-ons/community-fish/detector_community_fish_rf_detr_medium.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Community Fish Detector
+# Title: Community Fish RF-DETR Detector
 #
-# Description: Runs the cfd_rf_detr_m_1024 RF-DETR model for fish detection.
-# Outputs to computed_detections.csv.
+# Description: Community fish RF-DETR medium model run on the whole frame.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/community-fish/detector_community_fish_rf_detr_medium_grid.pipe
+++ b/configs/add-ons/community-fish/detector_community_fish_rf_detr_medium_grid.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Community Fish Detector
+# Title: Community Fish RF-DETR Grid Detector
 #
-# Description: Runs the cfd_rf_detr_m_1024 RF-DETR model, gridded, for fish detection.
-# Outputs to computed_detections.csv.
+# Description: Community fish RF-DETR medium model run over a grid of tiles plus
+# the whole frame, for small fish in large images.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/community-fish/detector_community_fish_yolo12x.pipe
+++ b/configs/add-ons/community-fish/detector_community_fish_yolo12x.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Community Fish Detector
+# Title: Community Fish YOLOv12x Detector
 #
-# Description: Runs the cfd_yolov12x ultralytics model for fish detection.
-# Outputs to computed_detections.csv.
+# Description: Community fish YOLOv12x model run on the whole frame.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/community-fish/tracker_community_fish.pipe
+++ b/configs/add-ons/community-fish/tracker_community_fish.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: Community Fish Tracker
 #
-# Description: Runs the cfd_yolov12x ultralytics model for fish detection
-# with ByteTrack multi-object tracking. Outputs to computed_tracks.csv.
+# Description: Community fish YOLOv12x detector followed by ByteTrack
+# multi-object tracking.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/darknet-yolo/embedded_dual_stream/train_yolo_eo.pipe
+++ b/configs/add-ons/darknet-yolo/embedded_dual_stream/train_yolo_eo.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Training - YOLO EO
+# Title: YOLO EO Training
 #
-# Description: Training pipeline for model optimization. Uses YOLO-based
-# detection.
+# Description: Embedded YOLOv4 detector training on the optical stream.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/darknet-yolo/embedded_dual_stream/train_yolo_ir.pipe
+++ b/configs/add-ons/darknet-yolo/embedded_dual_stream/train_yolo_ir.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Training - YOLO IR
+# Title: YOLO IR Training
 #
-# Description: Training pipeline for model optimization. Uses YOLO-based
-# detection.
+# Description: Embedded YOLOv4 detector training on the thermal stream.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/darknet-yolo/embedded_single_stream/train_deep_detector_yolo.pipe
+++ b/configs/add-ons/darknet-yolo/embedded_single_stream/train_deep_detector_yolo.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Training - Deep Detector YOLO
+# Title: YOLO Detector Training
 #
-# Description: Runs object detection pipeline on input imagery. Uses
-# YOLO-based detection.
+# Description: Embedded YOLOv4 detector training from input tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/darknet-yolo/templates/detector_yolo_wtf.pipe
+++ b/configs/add-ons/darknet-yolo/templates/detector_yolo_wtf.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: YOLO Detector With Temporal Features (WTF)
+# Title: YOLO Temporal Features Detector Template
 #
-# Description: YOLO Detector With Temporal Features (WTF) Outputs to
-# computed_detections.csv.
+# Description: Darknet detector on RGB merged with a color-commonality map and a
+# 20-frame motion variance image. Model slots are filled at train time; frames
+# must be in temporal order.
 # =============================================================================
 
 process input

--- a/configs/add-ons/darknet-yolo/templates/embedded_yolo_wtf.pipe
+++ b/configs/add-ons/darknet-yolo/templates/embedded_yolo_wtf.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: YOLO Detector With Temporal Features (WTF)
+# Title: Embedded YOLO Temporal Features Detector Template
 #
-# Description: YOLO Detector With Temporal Features (WTF)
+# Description: Embedded darknet detector on RGB merged with a color-commonality
+# map and a 20-frame motion variance image. Model slots are filled at train
+# time.
 # =============================================================================
 
 process detector_input

--- a/configs/add-ons/dino/measurement_from_annotations_default.pipe
+++ b/configs/add-ons/dino/measurement_from_annotations_default.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Measurement from annotations pipeline
+# Title: Default Measurement from Annotations
 #
-# Description: Default measurement from annotations pipeline.
-# Outputs to computed_tracks.csv.
+# Description: Default choice: stereo lengths from annotated head/tail keypoints
+# with NCC epipolar template matching.
 #
 # Requires Calibration: True
 # =============================================================================

--- a/configs/add-ons/dino/measurement_from_annotations_ncc_dino.pipe
+++ b/configs/add-ons/dino/measurement_from_annotations_ncc_dino.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Measurement from annotations pipeline
+# Title: DINO Measurement from Annotations
 #
-# Description: Measurement from annotations pipeline
+# Description: Stereo lengths from annotated head/tail keypoints. Right-camera
+# matches are found along the epipolar line by DINOv2 candidate selection plus
+# NCC template matching.
 #
 # Requires Calibration: True
 # =============================================================================

--- a/configs/add-ons/fdn-stereo/common_foundation_stereo.pipe
+++ b/configs/add-ons/fdn-stereo/common_foundation_stereo.pipe
@@ -1,12 +1,8 @@
 # =============================================================================
-# Title: Common Foundation Stereo Configuration
+# Title: Foundation Stereo Config
 #
-# Description: Shared configuration for Foundation Stereo deep learning model.
-# Used for high-quality disparity estimation in stereo pipelines and
-# interactive stereo annotation in DIVE.
-#
-# This file can be included in other pipelines or read directly by Python
-# services for consistent model configuration.
+# Description: Shared Foundation Stereo model settings (small variant, disparity
+# output) used by the interactive stereo service and the stereo pipelines.
 # =============================================================================
 
 # Foundation-Stereo deep learning model configuration

--- a/configs/add-ons/fdn-stereo/measurement_from_annotations_default.pipe
+++ b/configs/add-ons/fdn-stereo/measurement_from_annotations_default.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Measurement from annotations pipeline
+# Title: Default Measurement from Annotations
 #
-# Description: Default measurement from annotations pipeline.
-# Outputs to computed_tracks2.csv.
+# Description: Default choice: stereo lengths from annotated keypoints using
+# Foundation Stereo disparity.
 #
 # Requires Calibration: True
 # =============================================================================

--- a/configs/add-ons/fdn-stereo/measurement_from_annotations_fdn_stereo_s.pipe
+++ b/configs/add-ons/fdn-stereo/measurement_from_annotations_fdn_stereo_s.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Measurement from annotations pipeline
+# Title: Foundation Stereo Measurement from Annotations
 #
-# Description: Measurement from annotations pipeline Uses model: foundation_stereo_s.pth.
-# Outputs to computed_tracks2.csv.
+# Description: Stereo lengths from annotated head/tail keypoints. A dense
+# Foundation Stereo disparity map places the right-camera keypoint where only
+# the left view is annotated.
 #
 # Requires Calibration: True
 # =============================================================================

--- a/configs/add-ons/generic/common_generic_detector.pipe
+++ b/configs/add-ons/generic/common_generic_detector.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Generates generic object proposals, not specific class labels
+# Title: Generic Proposal Detector
 #
-# Description: Generates single-class generic object proposals output, with
-# boxes around many things in the scene which are likely to be objects, but
-# without specifying what those objects are.
+# Description: Windowed RF-DETR detector emitting single-class boxes around
+# likely objects without naming them.
 # =============================================================================
 
 process detector_input

--- a/configs/add-ons/generic/detector_generic_proposals.pipe
+++ b/configs/add-ons/generic/detector_generic_proposals.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Default Generic Detector Pipeline
+# Title: Generic Object Proposal Detector
 #
-# Description: Runs pre-trained object detector aimed at generating generic
-# object proposals Outputs to computed_detections.csv.
+# Description: Windowed RF-DETR generic proposal detector producing
+# class-agnostic object boxes.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/add-ons/generic/detector_svm_over_generic_proposals.pipe
+++ b/configs/add-ons/generic/detector_svm_over_generic_proposals.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Detection pipeline with SVM rapid model filters
+# Title: SVM Classifier Over Generic Proposals
 #
-# Description: Runs pre-trained object detector followed by SVM class filters.
-# Outputs to svm_detections.csv.
+# Description: Generic RF-DETR proposals classified with the user's trained SVM
+# models, then merged.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/add-ons/generic/embedded_single_stream/generic_proposal_tracker.pipe
+++ b/configs/add-ons/generic/embedded_single_stream/generic_proposal_tracker.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
 # Title: Generic Proposal Tracker
 #
-# Description: Pipeline configuration file.
+# Description: Embedded generic proposal detector followed by the default
+# ByteTrack tracker.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/embedded_single_stream/local_svm_detector.pipe
+++ b/configs/add-ons/generic/embedded_single_stream/local_svm_detector.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
 # Title: Local SVM Detector
 #
-# Description: Pipeline configuration file.
+# Description: Embedded generic proposals classified with the user's trained SVM
+# models; detections are emitted as single-frame tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/embedded_single_stream/local_svm_detector_with_def_tracker.pipe
+++ b/configs/add-ons/generic/embedded_single_stream/local_svm_detector_with_def_tracker.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Local SVM Detector With Def Tracker
+# Title: Local SVM Detector With Default Tracker
 #
-# Description: Runs object detection pipeline on input imagery. Uses
-# ../generic detector configuration.
+# Description: Embedded generic proposals classified with the user's trained SVM
+# models, followed by the default ByteTrack tracker.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/index_generic.pipe
+++ b/configs/add-ons/generic/index_generic.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Ingest video pipeline using pytorch descriptors
+# Title: Generic Proposal Index
 #
-# Description: Pipeline configuration file.
+# Description: Indexes video for image queries: generic proposals with per-box
+# descriptors, written to a KWA archive and the database.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/index_generic.svm.pipe
+++ b/configs/add-ons/generic/index_generic.svm.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Ingest video pipeline using pytorch descriptors
+# Title: Generic Proposal SVM Training Index
 #
-# Description: Pipeline configuration file.
+# Description: Merges generic proposals with the input annotations, computes
+# descriptors, writes positive/negative id lists for SVM training and ingests
+# them into the database.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/index_generic.trk.pipe
+++ b/configs/add-ons/generic/index_generic.trk.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Ingest video pipeline using pytorch descriptors
+# Title: Generic Proposal Track Index
 #
-# Description: Pipeline configuration file.
+# Description: Indexes video for track queries: generic proposals linked by
+# ByteTrack with descriptors averaged per track, written to a KWA archive and
+# the database.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/query_image_exemplar.pipe
+++ b/configs/add-ons/generic/query_image_exemplar.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Query Image Exemplar
+# Title: Image Exemplar Query
 #
-# Description: Pipeline configuration file.
+# Description: Embedded query pipeline: runs generic proposals on the exemplar
+# image (skipped when boxes are supplied) plus a full-image box, and returns
+# their descriptors.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/templates/detector_generic_netharn.pipe
+++ b/configs/add-ons/generic/templates/detector_generic_netharn.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Secondary Classifier After Generic Object Proposals
+# Title: NetHarn Classifier Over Generic Proposals Template
 #
-# Description: Secondary Classifier After Generic Object Proposals Outputs to
-# computed_detections.csv.
+# Description: Generic RF-DETR proposals reclassified by a trained NetHarn
+# classifier, then NMS.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/templates/detector_generic_svm.pipe
+++ b/configs/add-ons/generic/templates/detector_generic_svm.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: SVM Classifier on top of Generic Object Detections
+# Title: SVM Classifier Over Generic Proposals Template
 #
-# Description: SVM Classifier on top of Generic Object Detections Outputs to
-# computed_detections.csv.
+# Description: Generic RF-DETR proposals, default descriptor and trained SVM
+# refiner (models next to this file), then NMS.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/generic/tracker_generic_proposals.pipe
+++ b/configs/add-ons/generic/tracker_generic_proposals.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Example simple tracker pipeline
+# Title: Generic Proposal Tracker
 #
-# Description: Runs a standalone TUT object tracking pipeline Outputs to
-# computed_tracks.csv.
+# Description: Generic RF-DETR proposal detector followed by the default
+# ByteTrack tracker.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/add-ons/generic/tracker_svm_models.pipe
+++ b/configs/add-ons/generic/tracker_svm_models.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Detection pipeline with SVM rapid model filters
+# Title: SVM Over Generic Proposals Tracker
 #
-# Description: Runs pre-trained object detector followed by SVM class filters.
-# Outputs to computed_tracks.csv.
+# Description: Generic proposals classified with the user's trained SVM models,
+# merged and linked by the default ByteTrack tracker.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/add-ons/gfit/common_gfit_classifier_groups_v3.pipe
+++ b/configs/add-ons/gfit/common_gfit_classifier_groups_v3.pipe
@@ -1,5 +1,5 @@
 # =============================================================================
-# Title: GFIT v3 groups classifier
+# Title: GFIT v3 Groups Classifier
 #
 # Description: Two-classifier ensemble over the fused detections. The large
 # classifier's output is blended with the detector's class scores, then the

--- a/configs/add-ons/gfit/common_gfit_classifier_species_v3.pipe
+++ b/configs/add-ons/gfit/common_gfit_classifier_species_v3.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: GFIT v3 species classifier
+# Title: GFIT v3 Species Classifier
 #
-# Description: Single large classifier over the fused detections. Its output is
-# blended with the detector's own class scores at prior_weight.
+# Description: NetHarn species classifier over the fused detections. Group
+# scores are blended in through the group-to-species taxonomy.
 # =============================================================================
 
 process classifier_species_large

--- a/configs/add-ons/gfit/common_gfit_tracker_v3.pipe
+++ b/configs/add-ons/gfit/common_gfit_tracker_v3.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: GFIT v3 tracker
+# Title: GFIT v3 ByteTrack Tracker
 #
-# Description: ByteTrack, tuned on the fused detection CSVs. Tracking is driven
-# by detection confidence, not by the class labels.
+# Description: ByteTrack tuned on the fused GFIT detections. Association is
+# driven by detection confidence, not class label.
 # =============================================================================
 
 process tracker

--- a/configs/add-ons/gfit/detector_gfit_groups_v3.pipe
+++ b/configs/add-ons/gfit/detector_gfit_groups_v3.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: GFIT v3 groups Detector Pipe
+# Title: GFIT v3 Groups Detector
 #
-# Description: Fused SEFSC group + FishTrack motion detectors, reclassified to
-# groups. Outputs computed_detections.csv.
+# Description: Fused SEFSC group and FishTrack motion RF-DETR detectors,
+# reclassified to groups.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/gfit/detector_gfit_species_v3.pipe
+++ b/configs/add-ons/gfit/detector_gfit_species_v3.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: GFIT v3 species Detector Pipe
+# Title: GFIT v3 Species Detector
 #
-# Description: Fused SEFSC group + FishTrack motion detectors, reclassified to
-# species. Outputs computed_detections.csv.
+# Description: Fused SEFSC group and FishTrack motion RF-DETR detectors,
+# reclassified to groups and then species.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/gfit/measurement_gfit_groups_v3_seagis_dual.pipe
+++ b/configs/add-ons/gfit/measurement_gfit_groups_v3_seagis_dual.pipe
@@ -1,15 +1,9 @@
 # =============================================================================
-# Title: GFIT Stereo Measurement (Dual Camera Detection)
+# Title: GFIT SEAGIS Dual-Camera Stereo Measurement
 #
-# Description: Stereo measurement pipeline that runs detection, classification,
-# SAM2 segmentation, head/tail keypoint identification, and tracking on BOTH
-# left and right cameras independently. The SEAGIS measurement process handles
-# track pairing (detection matching, ID unification, class averaging) and
-# triangulates matched keypoints for 3D measurements, with epipolar template
-# matching as fallback for tracks where only one camera has keypoints.
-#
-# Requires: SEAGIS .CAM calibration files for left and right cameras.
-#
+# Description: GFIT detection, SAM2 segmentation, head/tail keypoints and
+# tracking on both cameras. SEAGIS pairs the tracks and triangulates lengths
+# from .CamCAL files.
 # Requires Calibration: True
 # =============================================================================
 

--- a/configs/add-ons/gfit/measurement_gfit_groups_v3_seagis_sing.pipe
+++ b/configs/add-ons/gfit/measurement_gfit_groups_v3_seagis_sing.pipe
@@ -1,15 +1,9 @@
 # =============================================================================
-# Title: GFIT Stereo Measurement (Single Camera Detection)
+# Title: GFIT SEAGIS Single-Camera Stereo Measurement
 #
-# Description: Stereo measurement pipeline that detects/tracks on the LEFT
-# camera only. SAM2 segmentation and head/tail keypoint identification are
-# applied to left-camera detections. The tracked result is fed to both inputs
-# of the SEAGIS measurement process along with both stereo images. SEAGIS
-# uses epipolar template matching to find corresponding right-camera points
-# for each left-camera keypoint, then triangulates to produce 3D measurements.
-#
-# Requires: SEAGIS .CAM calibration files for left and right cameras.
-#
+# Description: GFIT detection, SAM2 segmentation, head/tail keypoints and
+# tracking on the left camera only. SEAGIS finds the right-camera points by
+# epipolar template matching and triangulates lengths from .CamCAL files.
 # Requires Calibration: True
 # =============================================================================
 

--- a/configs/add-ons/gfit/measurement_gfit_groups_v3_viame_dual.pipe
+++ b/configs/add-ons/gfit/measurement_gfit_groups_v3_viame_dual.pipe
@@ -1,12 +1,9 @@
 # =============================================================================
-# Title: GFIT Stereo Measurement (Dual Camera Detection, Core)
+# Title: GFIT Core Dual-Camera Stereo Measurement
 #
-# Description: Stereo measurement pipeline that runs detection, classification,
-# SAM2 segmentation, head/tail keypoint identification, and tracking on BOTH
-# left and right cameras independently. The core measurement process handles
-# track pairing (detection matching, ID unification, class averaging) and
-# triangulates matched keypoints for 3D measurements using calibration data.
-#
+# Description: GFIT detection, SAM2 segmentation, head/tail keypoints and
+# tracking on both cameras. The core measurement process pairs the tracks and
+# triangulates lengths from the calibration file.
 # Requires Calibration: True
 # =============================================================================
 

--- a/configs/add-ons/gfit/measurement_gfit_groups_v3_viame_sing.pipe
+++ b/configs/add-ons/gfit/measurement_gfit_groups_v3_viame_sing.pipe
@@ -1,13 +1,9 @@
 # =============================================================================
-# Title: GFIT Stereo Measurement (Single Camera Detection, Core)
+# Title: GFIT Core Single-Camera Stereo Measurement
 #
-# Description: Stereo measurement pipeline that detects/tracks on the LEFT
-# camera only. SAM2 segmentation and head/tail keypoint identification are
-# applied to left-camera detections. The tracked result is fed to the left
-# input of the core measurement process along with both stereo images. The
-# measurement process uses epipolar NCC template matching to find
-# corresponding right-camera keypoints and triangulates for 3D measurements.
-#
+# Description: GFIT detection, SAM2 segmentation, head/tail keypoints and
+# tracking on the left camera only. The core measurement process finds the
+# right-camera points by epipolar template matching and triangulates lengths.
 # Requires Calibration: True
 # =============================================================================
 

--- a/configs/add-ons/gfit/tracker_gfit_groups_v3.pipe
+++ b/configs/add-ons/gfit/tracker_gfit_groups_v3.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: GFIT v3 groups Tracker Pipe
+# Title: GFIT v3 Groups Tracker
 #
-# Description: Fused detector, groups reclassification, then SRNN tracking.
+# Description: Fused GFIT detector and groups classifier followed by ByteTrack.
+# Tracks shorter than 3 states are dropped.
 # =============================================================================
 
 config _scheduler

--- a/configs/add-ons/gfit/tracker_gfit_species_v3.pipe
+++ b/configs/add-ons/gfit/tracker_gfit_species_v3.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: GFIT v3 species Tracker Pipe
+# Title: GFIT v3 Species Tracker
 #
-# Description: Fused detector, species reclassification, then SRNN tracking.
+# Description: Fused GFIT detector, groups then species classification, followed
+# by ByteTrack. Tracks shorter than 3 states are dropped.
 # =============================================================================
 
 config _scheduler

--- a/configs/add-ons/gfit/utility_link_detections_gfit_v3.pipe
+++ b/configs/add-ons/gfit/utility_link_detections_gfit_v3.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Link or re-link detections into tracks using the default tracker
+# Title: GFIT v3 Detection Linker
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Links existing detections into tracks with the GFIT ByteTrack
+# tracker without re-running detection.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/common_color_correction_left.pipe
+++ b/configs/add-ons/habcam/common_color_correction_left.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Optionally debayers and enhances the image if it isn't already RGB (3-channel)
+# Title: Left Debayer and Enhance Filter
 #
-# Description: Shared configuration module that can be included by other
-# pipelines.
+# Description: Debayers and enhances the left image; enhancement is skipped when
+# the input is already RGB.
 # =============================================================================
 
 process left_image_debayer

--- a/configs/add-ons/habcam/common_color_correction_right.pipe
+++ b/configs/add-ons/habcam/common_color_correction_right.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Optionally debayers and enhances the image if it isn't already RGB (3-channel)
+# Title: Right Debayer and Enhance Filter
 #
-# Description: Shared configuration module that can be included by other
-# pipelines.
+# Description: Debayers and enhances the right image; enhancement is skipped
+# when the input is already RGB.
 # =============================================================================
 
 process right_image_debayer

--- a/configs/add-ons/habcam/common_habcam_input.pipe
+++ b/configs/add-ons/habcam/common_habcam_input.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: HabCam Input Configuration
+# Title: HabCam Stereo Image Input
 #
-# Description: Shared input configuration for reading images or video frames.
-# Configured for HabCam underwater survey imagery.
+# Description: Left HabCam input plus debayering and enhancement of the right
+# half.
 # =============================================================================
 
 # ============================= INPUT FRAME LIST ==============================

--- a/configs/add-ons/habcam/common_habcam_input_left.pipe
+++ b/configs/add-ons/habcam/common_habcam_input_left.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: HabCam Input Configuration
+# Title: HabCam Left Image Input
 #
-# Description: Shared input configuration for reading images or video frames.
-# Configured for HabCam underwater survey imagery.
+# Description: Reads and downsamples HabCam imagery, keeps the left half of a
+# stitched pair (or the full image) and debayers and enhances it.
 # =============================================================================
 
 # ============================= INPUT FRAME LIST ==============================

--- a/configs/add-ons/habcam/common_scallop_four_class_detector_left.pipe
+++ b/configs/add-ons/habcam/common_scallop_four_class_detector_left.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Common - Scallop Four Class Detector Left
+# Title: Left Four-Class Scallop Detector
 #
-# Description: Shared detector configuration that can be included by other
-# pipelines. Uses model: scallop_yolo_v7_one_class.weights.
+# Description: Cascade R-CNN, HRNet and YOLOv7 scallop detectors with an
+# EfficientNet reclassifier, fused by NMS into live, swimming, dead and clapper
+# classes.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/habcam/common_scallop_four_class_detector_right.pipe
+++ b/configs/add-ons/habcam/common_scallop_four_class_detector_right.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Common - Scallop Four Class Detector Right
+# Title: Right Four-Class Scallop Detector
 #
-# Description: Shared detector configuration that can be included by other
-# pipelines. Uses model: scallop_yolo_v7_one_class.weights.
+# Description: Cascade R-CNN, HRNet and YOLOv7 scallop detectors with an
+# EfficientNet reclassifier, fused by NMS into live, swimming, dead and clapper
+# classes.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/habcam/common_scallop_one_class_detector_left.pipe
+++ b/configs/add-ons/habcam/common_scallop_one_class_detector_left.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Common - Scallop One Class Detector Left
+# Title: Left One-Class Scallop Detector
 #
-# Description: Shared detector configuration that can be included by other
-# pipelines. Uses model: scallop_yolo_v7_one_class.weights.
+# Description: Cascade R-CNN, HRNet and YOLOv7 scallop detectors with an
+# EfficientNet reclassifier, fused by NMS into a single scallop class.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/habcam/common_scallop_one_class_detector_right.pipe
+++ b/configs/add-ons/habcam/common_scallop_one_class_detector_right.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Common - Scallop One Class Detector Right
+# Title: Right One-Class Scallop Detector
 #
-# Description: Shared detector configuration that can be included by other
-# pipelines. Uses model: scallop_yolo_v7_one_class.weights.
+# Description: Cascade R-CNN, HRNet and YOLOv7 scallop detectors with an
+# EfficientNet reclassifier, fused by NMS into a single scallop class.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/habcam/detector_habcam_measure_scallops_four_class_metadata.pipe
+++ b/configs/add-ons/habcam/detector_habcam_measure_scallops_four_class_metadata.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: Four-Class Scallop Detector with Metadata Measurement
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections_left.csv.
-# Configured for scallop detection in benthic imagery.
+# Description: Four-class scallop ensemble on the left (or unstitched) image,
+# with sizes computed from the image's embedded HabCam metadata.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_measure_scallops_four_class_stereo.pipe
+++ b/configs/add-ons/habcam/detector_habcam_measure_scallops_four_class_stereo.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: Four-Class Scallop Detector with Stereo Measurement
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input configuration. Outputs results to computed_detections_right.csv.
-# Configured for scallop detection in benthic imagery.
+# Description: Four-class scallop ensemble on both halves of a stitched pair,
+# with sizes computed by stereo measurement. Writes a detection file per side.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_measure_scallops_one_class_metadata.pipe
+++ b/configs/add-ons/habcam/detector_habcam_measure_scallops_one_class_metadata.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: One-Class Scallop Detector with Metadata Measurement
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections_left.csv.
-# Configured for scallop detection in benthic imagery.
+# Description: One-class scallop ensemble on the left (or unstitched) image,
+# with sizes computed from the image's embedded HabCam metadata.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_measure_scallops_one_class_stereo.pipe
+++ b/configs/add-ons/habcam/detector_habcam_measure_scallops_one_class_stereo.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: One-Class Scallop Detector with Stereo Measurement
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input configuration. Outputs results to computed_detections_right.csv.
-# Configured for scallop detection in benthic imagery.
+# Description: One-class scallop ensemble on both halves of a stitched pair,
+# with sizes computed by stereo measurement. Writes a detection file per side.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_scallop_and_flatfish.pipe
+++ b/configs/add-ons/habcam/detector_habcam_scallop_and_flatfish.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Habcam Pipeline
+# Title: HabCam Scallop and Fish Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv.
-# Configured for scallop detection in benthic imagery.
+# Description: One-class scallop ensemble plus a YOLO fish detector (skate,
+# roundfish, flatfish, otherfish) on the left (or unstitched) image.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_scallop_four_class.pipe
+++ b/configs/add-ons/habcam/detector_habcam_scallop_four_class.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: HabCam Four-Class Scallop Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv.
-# Configured for scallop detection in benthic imagery.
+# Description: Four-class scallop ensemble (live, swimming, dead, clapper) on
+# the left half of a stitched pair, or the full image if unstitched.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_scallop_one_class.pipe
+++ b/configs/add-ons/habcam/detector_habcam_scallop_one_class.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: HabCam One-Class Scallop Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv.
-# Configured for scallop detection in benthic imagery.
+# Description: One-class scallop ensemble on the left half of a stitched pair,
+# or the full image if unstitched.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_substrate.pipe
+++ b/configs/add-ons/habcam/detector_habcam_substrate.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Atlantic Substrate Classifier from HABCAM Vehicles
+# Title: HabCam Atlantic Substrate Classifier
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv.
+# Description: Whole-frame ONNX classifiers for substrate types (boulder,
+# gravel, sand waves, shell, sponges, scallop bed, ...) merged into one
+# detection set.
 # =============================================================================
 
 # global pipeline config

--- a/configs/add-ons/habcam/detector_habcam_test_cfrnn_only.pipe
+++ b/configs/add-ons/habcam/detector_habcam_test_cfrnn_only.pipe
@@ -1,9 +1,7 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: HabCam Cascade R-CNN Test Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv. Uses
-# Cascade R-CNN detection.
+# Description: Runs only the Cascade R-CNN member of the scallop ensemble.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_test_hrnet_only.pipe
+++ b/configs/add-ons/habcam/detector_habcam_test_hrnet_only.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: HabCam HRNet Test Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv.
+# Description: Runs only the HRNet member of the scallop ensemble.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_test_multi_species_only.pipe
+++ b/configs/add-ons/habcam/detector_habcam_test_multi_species_only.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Detector, scallop-only trained using netharn
+# Title: HabCam Multi-Species Test Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv.
+# Description: Runs only the multi-category Cascade R-CNN detector.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_test_reclassifier_input_only.pipe
+++ b/configs/add-ons/habcam/detector_habcam_test_reclassifier_input_only.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: HabCam Reclassifier Input Test
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv.
+# Description: Writes the merged detections that feed the four-class
+# reclassifier instead of the fused result.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_test_reclassifier_output_only.pipe
+++ b/configs/add-ons/habcam/detector_habcam_test_reclassifier_output_only.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: HabCam Reclassifier Output Test
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv.
+# Description: Writes only the EfficientNet reclassifier output instead of the
+# fused result.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/detector_habcam_test_yolo_only.pipe
+++ b/configs/add-ons/habcam/detector_habcam_test_yolo_only.pipe
@@ -1,9 +1,7 @@
 # =============================================================================
-# Title: Process the left image (or full image if non-stitched pair)
+# Title: HabCam YOLOv7 Test Detector
 #
-# Description: Runs object detection pipeline on input imagery. Uses habcam
-# input left configuration. Outputs results to computed_detections.csv. Uses
-# YOLO-based detection.
+# Description: Runs only the YOLOv7 member of the scallop ensemble.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/utility_habcam_debayer_and_enhance_left.pipe
+++ b/configs/add-ons/habcam/utility_habcam_debayer_and_enhance_left.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Debayer and color correct the left image only on a given input or input pair
+# Title: HabCam Left Debayer and Enhance
 #
-# Description: Applies image enhancement filters to input imagery. Configured
-# for HabCam underwater survey imagery.
+# Description: Debayers and color corrects the left half of a stitched pair (or
+# the full image) and writes PNG files.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/habcam/utility_habcam_debayer_and_enhance_right.pipe
+++ b/configs/add-ons/habcam/utility_habcam_debayer_and_enhance_right.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Debayer and color correct the left image only on a given input or input pair
+# Title: HabCam Right Debayer and Enhance
 #
-# Description: Applies image enhancement filters to input imagery. Configured
-# for HabCam underwater survey imagery.
+# Description: Debayers and color corrects the right half of a stitched pair and
+# writes PNG files.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/ifremer/measurement_detect_fish_only.pipe
+++ b/configs/add-ons/ifremer/measurement_detect_fish_only.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Stereo detect fish
+# Title: Stereo Fish Detector with Disparity Pairing
 #
-# Description: Pipeline for measuring object dimensions in imagery.
-#
+# Description: RF-DETR fish detection on both cameras, with left/right
+# detections paired through an SGBM disparity map.
 # Requires Calibration: True
 # Calibration Keys: depth_map:computer:ocv_stereo_disparity:calibration_file stereo_pairing:calibration_file
 # =============================================================================

--- a/configs/add-ons/ifremer/measurement_track_fish_in_3d_from_rect_disp.pipe
+++ b/configs/add-ons/ifremer/measurement_track_fish_in_3d_from_rect_disp.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: track fish 3d from detections and stereo rectified disparity
+# Title: Stereo Fish Tracker with 3D Pairing
 #
-# Description: Pipeline for measuring object dimensions in imagery.
-#
+# Description: RF-DETR fish detection and SRNN tracking on both cameras, with
+# tracks paired in 3D through an SGBM disparity map.
 # Requires Calibration: True
 # Calibration Keys: depth_map:computer:ocv_stereo_disparity:calibration_file stereo_pairing:calibration_file
 # =============================================================================

--- a/configs/add-ons/ifremer/measurement_track_fish_only.pipe
+++ b/configs/add-ons/ifremer/measurement_track_fish_only.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Tracker piepline for fish on stereo cameras
+# Title: Stereo Fish Tracker
 #
-# Description: Pipeline for measuring object dimensions in imagery.
+# Description: RF-DETR fish detection and SRNN tracking on both cameras
+# independently, with no stereo pairing.
 # =============================================================================
 
 include common_stereo_fish_tracker.pipe

--- a/configs/add-ons/learn/detector_convnext_baseline_xl.pipe
+++ b/configs/add-ons/learn/detector_convnext_baseline_xl.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: MMDet Cascade Faster R-CNN Detector
+# Title: ConvNeXt-XL Cascade Mask R-CNN Detector
 #
-# Description: MMDet Cascade Faster R-CNN Detector Uses model:
-# convnext_cascade_mask_rcnn_xlarge_22k_3x.pt. Outputs to
-# computed_detections.csv.
+# Description: MMDetection ConvNeXt-XLarge Cascade Mask R-CNN run in adaptive
+# windows with NMS.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/learn/detector_cutler_10_shot_poolcar.pipe
+++ b/configs/add-ons/learn/detector_cutler_10_shot_poolcar.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: MMDet Cascade Faster R-CNN Detector
+# Title: CutLER 10-Shot Poolcar Detector
 #
-# Description: MMDet Cascade Faster R-CNN Detector Uses model:
-# poolcar_10_shot.pt. Outputs to computed_detections.csv.
+# Description: ConvNeXt-XL Cascade R-CNN fine-tuned from CutLER on 10 poolcar
+# shots, run in adaptive windows with NMS.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/learn/detector_maskcut_unspvr_segmenter.pipe
+++ b/configs/add-ons/learn/detector_maskcut_unspvr_segmenter.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: CutLer's MaskCut Pipeline
+# Title: MaskCut Unsupervised Segmenter
 #
-# Description: Runs object detection pipeline on input imagery. Uses default
-# input with downsampler configuration. Outputs results to
-# computed_detections.csv.
+# Description: CutLER's MaskCut produces class-agnostic object masks for each
+# frame.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/learn/detector_remax_convnext_novelty_detection.pipe
+++ b/configs/add-ons/learn/detector_remax_convnext_novelty_detection.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Remax Novelty Detection
+# Title: ReMax ConvNeXt Novelty Detector
 #
-# Description: Remax Novelty Detection Uses model: convnext_xview_base.pt.
-# Outputs to computed_detections.csv.
+# Description: ConvNeXt xView detector with a ReMax novelty model scoring
+# detections as known or novel.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/add-ons/learn/detector_remax_dino_novelty_detection.pipe
+++ b/configs/add-ons/learn/detector_remax_dino_novelty_detection.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Remax Novelty Detection
+# Title: ReMax DINO Novelty Detector
 #
-# Description: Remax Novelty Detection Uses model: pytorch_dino.pt. Outputs to
-# computed_detections.csv.
+# Description: DINO Swin xView detector with a ReMax novelty model scoring
+# detections as known or novel.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/add-ons/nwfsc-auv/measurement_nwfsc_auv_auto.pipe
+++ b/configs/add-ons/nwfsc-auv/measurement_nwfsc_auv_auto.pipe
@@ -1,22 +1,10 @@
 # =============================================================================
-# Title: NWFSC AUV Stereo Measurement (Dual Camera Detection, Core)
+# Title: NWFSC AUV Stereo Measurement
 #
-# Description: Stereo measurement pipeline that runs detection, SAM2
-# segmentation, and head/tail keypoint identification on BOTH left and right
-# cameras independently. No temporal tracker is run -- each detection becomes
-# its own single-state track. The core measurement process handles pairing
-# (detection matching, ID unification, class averaging) and triangulates
-# matched keypoints for 3D measurements using calibration data.
-#
-# Detector classes: sponges, rockfish, corals, roundfish, flatfish
-#
-# Segmentation runs over every detection, but head/tail keypoints are only
-# assigned to the fish classes (rockfish, roundfish, flatfish). Because
-# compute_measurements only measures detections carrying both a "head" and a
-# "tail" keypoint on both cameras, restricting the keypoint stage is what
-# restricts measurement -- corals and sponges still flow through to the
-# output as segmented detections, just without a length.
-#
+# Description: NetHarn detection, SAM2 segmentation and head/tail keypoints on
+# both cameras, then stereo pairing and triangulation. Only fish classes
+# (rockfish, roundfish, flatfish) get keypoints and lengths; corals and sponges
+# pass through unmeasured.
 # Requires Calibration: True
 # =============================================================================
 

--- a/configs/add-ons/sam2/utility_add_head_tail_keypoints_default.pipe
+++ b/configs/add-ons/sam2/utility_add_head_tail_keypoints_default.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Utility - Add Head Tail Keypoints Default
+# Title: Default Add Head-Tail Keypoints
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Default choice: the SAM2 head-tail keypoint generator.
 # Input: BBOX
 # Output: HEAD-TAIL
 # =============================================================================

--- a/configs/add-ons/sam2/utility_add_head_tail_keypoints_sam2.pipe
+++ b/configs/add-ons/sam2/utility_add_head_tail_keypoints_sam2.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Add head tail keypoints to existing detections which lack them
+# Title: SAM2 Head-Tail Keypoint Generator
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Segments each box with SAM2 where no mask exists and derives head
+# and tail keypoints from the mask's oriented bounding box.
 # Input: BBOX
 # Output: HEAD-TAIL
 # =============================================================================

--- a/configs/add-ons/sam2/utility_add_segmentations_default.pipe
+++ b/configs/add-ons/sam2/utility_add_segmentations_default.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Utility - Add Segmentations Default
+# Title: Default Add Segmentations
 #
-# Description: Adds segmentation masks to existing detections.
+# Description: Default choice: the SAM2 segmentation generator.
 # Input: BBOX
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sam2/utility_add_segmentations_sam2.pipe
+++ b/configs/add-ons/sam2/utility_add_segmentations_sam2.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Add automatically generated segmentations via SAM2
+# Title: SAM2 Segmentation Generator
 #
-# Description: Adds segmentation masks to existing detections.
+# Description: Adds a SAM2 polygon mask to every existing box, replacing
+# existing masks when Replace is set.
 # Input: BBOX
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sam2/utility_track_selections_sam2.pipe
+++ b/configs/add-ons/sam2/utility_track_selections_sam2.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Track user selections and generate segmentation masks using SAM2
+# Title: SAM2 Selection Tracker
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Re-segments user-selected boxes with SAM2 and propagates them
+# through later frames into tracks. Existing multi-frame tracks pass through
+# unchanged.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sam3/detector_sam3_animals.pipe
+++ b/configs/add-ons/sam3/detector_sam3_animals.pipe
@@ -1,9 +1,9 @@
 # =============================================================================
 # Title: SAM3 Open-Vocabulary Detector
 #
-# Description: Detect objects in each frame using SAM3's built-in text-prompted
-#              detection. Produces per-frame detections with polygon masks.
-#              Set the text_query parameter to describe the objects to find.
+# Description: Per-frame text-prompted detection (Grounding DINO) segmented by
+# SAM3 into polygon masks. Edit the text query to choose the targets; the
+# default covers common animal groups.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sam3/detector_sam3_fish.pipe
+++ b/configs/add-ons/sam3/detector_sam3_fish.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
 # Title: SAM3 Fish Detector
 #
-# Description: Detect fish in each frame using SAM3's built-in text-prompted
-#              detection. Produces per-frame detections with polygon masks.
+# Description: Per-frame text-prompted fish detection (Grounding DINO) segmented
+# by SAM3 into polygon masks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sam3/tracker_sam3_animals.pipe
+++ b/configs/add-ons/sam3/tracker_sam3_animals.pipe
@@ -1,12 +1,9 @@
 # =============================================================================
 # Title: SAM3 Open-Vocabulary Tracker
 #
-# Description: Detect and track objects across frames using SAM3's native video
-#              predictor with text-prompted detection. Detects objects on the
-#              first frame (and periodically thereafter) then propagates them
-#              using SAM3's memory-attention tracking. Produces multi-frame
-#              tracks with polygon masks.
-#              Set the text_query parameter to describe the objects to find.
+# Description: Detects and tracks the text-query targets with SAM3's video
+# predictor, re-detecting every 10 frames and propagating with memory attention.
+# Outputs tracks with polygon masks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sam3/tracker_sam3_fish.pipe
+++ b/configs/add-ons/sam3/tracker_sam3_fish.pipe
@@ -1,11 +1,9 @@
 # =============================================================================
 # Title: SAM3 Fish Tracker
 #
-# Description: Detect and track fish across frames using SAM3's native video
-#              predictor with text-prompted detection. Detects fish on the
-#              first frame (and periodically thereafter) then propagates them
-#              using SAM3's memory-attention tracking. Produces multi-frame
-#              tracks with polygon masks.
+# Description: Detects and tracks fish with SAM3's video predictor, re-detecting
+# every 10 frames and propagating with memory attention. Outputs tracks with
+# polygon masks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sam3/utility_add_segmentations_sam3.pipe
+++ b/configs/add-ons/sam3/utility_add_segmentations_sam3.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Add automatically generated segmentations via SAM3
+# Title: SAM3 Segmentation Generator
 #
-# Description: Adds segmentation masks to existing detections using SAM3.
-#              This pipeline replaces existing masks with SAM3-generated masks.
+# Description: Adds a SAM3 polygon mask to every existing box, replacing
+# existing masks when Replace is set.
 # Input: BBOX
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sam3/utility_text_query_default.pipe
+++ b/configs/add-ons/sam3/utility_text_query_default.pipe
@@ -1,9 +1,7 @@
 # =============================================================================
-# Title: Refine tracks using SAM3 with text query support
+# Title: Default SAM3 Text Query
 #
-# Description: Utility pipeline for creating or refining tracks with text-based
-#              queries. Textual query support uses architectures derived from
-#              Meta's SAM3 project.
+# Description: Default choice: the tracked SAM3 text query.
 # =============================================================================
 
 include utility_text_query_sam3_tracking.pipe

--- a/configs/add-ons/sam3/utility_text_query_sam3_gridded.pipe
+++ b/configs/add-ons/sam3/utility_text_query_sam3_gridded.pipe
@@ -1,11 +1,8 @@
 # =============================================================================
-# Title: Text query via SAM3 (gridded for large images, no tracking)
+# Title: Gridded SAM3 Text Query
 #
-# Description: Textual query support uses architectures derived from Meta's
-#              SAM3 project. This variant uses windowed/gridded processing to
-#              improve detection of small objects in large images. Each frame
-#              is processed independently with no cross-frame tracking.
-#
+# Description: Per-frame text-prompted detection in 1008x1008 windows for small
+# objects in large images, segmented by SAM3. No cross-frame tracking.
 # Input: TEXT
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sam3/utility_text_query_sam3_no_tracking.pipe
+++ b/configs/add-ons/sam3/utility_text_query_sam3_no_tracking.pipe
@@ -1,12 +1,8 @@
 # =============================================================================
-# Title: Text query via SAM3 (per-frame, no tracking)
+# Title: Per-Frame SAM3 Text Query
 #
-# Description: Utility pipeline for detecting objects with text-based queries.
-#              Uses Grounding DINO for per-frame detection and SAM3 for
-#              segmentation. Each frame is processed independently with no
-#              cross-frame tracking. Suitable for image sets and videos where
-#              frame-to-frame correspondence is not needed.
-#
+# Description: Per-frame text-prompted detection (Grounding DINO) segmented by
+# SAM3 into polygon masks. No cross-frame tracking.
 # Input: TEXT
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sam3/utility_text_query_sam3_tracking.pipe
+++ b/configs/add-ons/sam3/utility_text_query_sam3_tracking.pipe
@@ -1,10 +1,9 @@
 # =============================================================================
-# Title: Refine tracks using SAM3 with text query support
+# Title: Tracked SAM3 Text Query
 #
-# Description: Utility pipeline for creating or refining tracks with text-based
-#              queries. Textual query support uses architectures derived from
-#              Meta's SAM3 project.
-#
+# Description: Creates or refines tracks for the text-query targets with SAM3's
+# video predictor, re-detecting every 10 frames and propagating with memory
+# attention.
 # Input: TEXT
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sam3/utility_track_selections_sam3.pipe
+++ b/configs/add-ons/sam3/utility_track_selections_sam3.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Track user selections and generate segmentation masks using SAM3
+# Title: SAM3 Selection Tracker
 #
-# Description: Utility pipeline for tracking user selections and adding
-#              segmentation masks using SAM3.
+# Description: Re-segments user-selected boxes with SAM3 and propagates them
+# through later frames into tracks. Existing multi-frame tracks pass through
+# unchanged.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_seven_class_cam1.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_seven_class_cam1.pipe
@@ -1,17 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Seven Class Cam1
+# Title: Sea Lion Seven-Class Fusion Detector (Cam 1)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses the DEIMv2 6-class
-# lifestage detector (ONNX, 640px) with the RF-DETR 8-class detector (1008px)
-# by weighted box fusion, keeping dead pup as its own seventh class rather than
-# folding it into pup. The DEIMv2 model has no dead-pup category, so the dead
-# pup label comes entirely from the RF-DETR 8-class model; DEIMv2 adds box
-# recall for the other six classes.
-#
-# Output classes: bull (B), sub-adult male (S), female (F), juvenile (J),
-# pup (P), northern fur seal (NFS), dead pup (DP). dead nonpup (DN) is omitted
-# so those detections are dropped.
+# Description: Weighted box fusion of the DEIMv2 six-class and RF-DETR
+# eight-class detectors for camera 1. Classes: B, S, F, J, P, NFS, DP; dead
+# nonpup (DN) is dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_seven_class_cam2.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_seven_class_cam2.pipe
@@ -1,17 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Seven Class Cam2
+# Title: Sea Lion Seven-Class Fusion Detector (Cam 2)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses the DEIMv2 6-class
-# lifestage detector (ONNX, 640px) with the RF-DETR 8-class detector (1008px)
-# by weighted box fusion, keeping dead pup as its own seventh class rather than
-# folding it into pup. The DEIMv2 model has no dead-pup category, so the dead
-# pup label comes entirely from the RF-DETR 8-class model; DEIMv2 adds box
-# recall for the other six classes.
-#
-# Output classes: bull (B), sub-adult male (S), female (F), juvenile (J),
-# pup (P), northern fur seal (NFS), dead pup (DP). dead nonpup (DN) is omitted
-# so those detections are dropped.
+# Description: Weighted box fusion of the DEIMv2 six-class and RF-DETR
+# eight-class detectors for camera 2. Classes: B, S, F, J, P, NFS, DP; dead
+# nonpup (DN) is dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_seven_class_cam3.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_seven_class_cam3.pipe
@@ -1,17 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Seven Class Cam3
+# Title: Sea Lion Seven-Class Fusion Detector (Cam 3)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses the DEIMv2 6-class
-# lifestage detector (ONNX, 640px) with the RF-DETR 8-class detector (1008px)
-# by weighted box fusion, keeping dead pup as its own seventh class rather than
-# folding it into pup. The DEIMv2 model has no dead-pup category, so the dead
-# pup label comes entirely from the RF-DETR 8-class model; DEIMv2 adds box
-# recall for the other six classes.
-#
-# Output classes: bull (B), sub-adult male (S), female (F), juvenile (J),
-# pup (P), northern fur seal (NFS), dead pup (DP). dead nonpup (DN) is omitted
-# so those detections are dropped.
+# Description: Weighted box fusion of the DEIMv2 six-class and RF-DETR
+# eight-class detectors for camera 3. Classes: B, S, F, J, P, NFS, DP; dead
+# nonpup (DN) is dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_six_class_cam1.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_six_class_cam1.pipe
@@ -1,15 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Six Class Cam1
+# Title: Sea Lion Six-Class Fusion Detector (Cam 1)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses the DEIMv2 6-class
-# lifestage detector (ONNX, 640px) with the RF-DETR 8-class detector (1008px)
-# using weighted box fusion.
-#
-# Output classes: bull (B), sub-adult male (S), female (F), juvenile (J),
-# pup (P), northern fur seal (NFS). The RF-DETR 8-class model's extra classes
-# fold via the fuser's label_dic: dead pup (DP) maps onto the pup id, and DN
-# (dead nonpup) is omitted so those detections are dropped.
+# Description: Weighted box fusion of the DEIMv2 six-class and RF-DETR
+# eight-class detectors for camera 1. Classes: B, S, F, J, P, NFS; dead pup
+# folds into pup, dead nonpup is dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_six_class_cam2.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_six_class_cam2.pipe
@@ -1,15 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Six Class Cam2
+# Title: Sea Lion Six-Class Fusion Detector (Cam 2)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses the DEIMv2 6-class
-# lifestage detector (ONNX, 640px) with the RF-DETR 8-class detector (1008px)
-# using weighted box fusion.
-#
-# Output classes: bull (B), sub-adult male (S), female (F), juvenile (J),
-# pup (P), northern fur seal (NFS). The RF-DETR 8-class model's extra classes
-# fold via the fuser's label_dic: dead pup (DP) maps onto the pup id, and DN
-# (dead nonpup) is omitted so those detections are dropped.
+# Description: Weighted box fusion of the DEIMv2 six-class and RF-DETR
+# eight-class detectors for camera 2. Classes: B, S, F, J, P, NFS; dead pup
+# folds into pup, dead nonpup is dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_six_class_cam3.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_six_class_cam3.pipe
@@ -1,15 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Six Class Cam3
+# Title: Sea Lion Six-Class Fusion Detector (Cam 3)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses the DEIMv2 6-class
-# lifestage detector (ONNX, 640px) with the RF-DETR 8-class detector (1008px)
-# using weighted box fusion.
-#
-# Output classes: bull (B), sub-adult male (S), female (F), juvenile (J),
-# pup (P), northern fur seal (NFS). The RF-DETR 8-class model's extra classes
-# fold via the fuser's label_dic: dead pup (DP) maps onto the pup id, and DN
-# (dead nonpup) is omitted so those detections are dropped.
+# Description: Weighted box fusion of the DEIMv2 six-class and RF-DETR
+# eight-class detectors for camera 3. Classes: B, S, F, J, P, NFS; dead pup
+# folds into pup, dead nonpup is dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_two_class_cam1.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_two_class_cam1.pipe
@@ -1,15 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Two Class Cam1
+# Title: Sea Lion Two-Class Fusion Detector (Cam 1)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses three detectors --
-# RF-DETR 2-class @1008, DEIMv2 pup-vs-nonpup @1280 (ONNX), and RF-DETR 8-class
-# @1008 (fine classes folded to non-pup/pup) -- with weighted box fusion.
-#
-# Output classes: non-pup (NP), pup (P). Label folding is done in the fuser's
-# label_dic: NP and the 8-class adult categories (B/F/J/S/DN) map onto the
-# non-pup id; P and DP map onto the pup id; NFS is omitted so northern fur
-# seals are dropped from the 2-class output.
+# Description: Weighted box fusion of the RF-DETR two-class, DEIMv2 two-class
+# and RF-DETR eight-class detectors for camera 1. Classes: non-pup (NP), pup
+# (P); northern fur seals are dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_two_class_cam2.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_two_class_cam2.pipe
@@ -1,15 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Two Class Cam2
+# Title: Sea Lion Two-Class Fusion Detector (Cam 2)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses three detectors --
-# RF-DETR 2-class @1008, DEIMv2 pup-vs-nonpup @1280 (ONNX), and RF-DETR 8-class
-# @1008 (fine classes folded to non-pup/pup) -- with weighted box fusion.
-#
-# Output classes: non-pup (NP), pup (P). Label folding is done in the fuser's
-# label_dic: NP and the 8-class adult categories (B/F/J/S/DN) map onto the
-# non-pup id; P and DP map onto the pup id; NFS is omitted so northern fur
-# seals are dropped from the 2-class output.
+# Description: Weighted box fusion of the RF-DETR two-class, DEIMv2 two-class
+# and RF-DETR eight-class detectors for camera 2. Classes: non-pup (NP), pup
+# (P); northern fur seals are dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_fusion_two_class_cam3.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_fusion_two_class_cam3.pipe
@@ -1,15 +1,9 @@
 # =============================================================================
-# Title: Common - Sea Lion Fusion Two Class Cam3
+# Title: Sea Lion Two-Class Fusion Detector (Cam 3)
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery. Fuses three detectors --
-# RF-DETR 2-class @1008, DEIMv2 pup-vs-nonpup @1280 (ONNX), and RF-DETR 8-class
-# @1008 (fine classes folded to non-pup/pup) -- with weighted box fusion.
-#
-# Output classes: non-pup (NP), pup (P). Label folding is done in the fuser's
-# label_dic: NP and the 8-class adult categories (B/F/J/S/DN) map onto the
-# non-pup id; P and DP map onto the pup id; NFS is omitted so northern fur
-# seals are dropped from the 2-class output.
+# Description: Weighted box fusion of the RF-DETR two-class, DEIMv2 two-class
+# and RF-DETR eight-class detectors for camera 3. Classes: non-pup (NP), pup
+# (P); northern fur seals are dropped.
 # =============================================================================
 
 # ============================== INPUT FORMATTER ==============================

--- a/configs/add-ons/sea-lion/common_sea_lion_registration_1cam.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_registration_1cam.pipe
@@ -1,50 +1,8 @@
 # =============================================================================
-# Title: Common - Sea Lion Registration 1cam
+# Title: One-Camera Sea Lion Survey Registration
 #
-# Description: Shared registration module, drop-in replacement for
-# common_sea_lion_stabilizer_1cam.pipe. Instead of frame-to-frame SURF/VXL
-# stabilization (many_image_stabilizer), the homographies come from the newer
-# whole-survey registration (viame.colmap.colmap_registration:
-# affine chains + rig cross-camera consensus + optional GPS/flight-log
-# geo-anchoring). Exposes the same process name (stabilizer) and output ports
-# (homog1/homog2/homog3), so the multicam suppressor / tracker / homography
-# writer downstream are unchanged.
-#
-# The process also needs the per-camera image PATHS to key its precomputed
-# homographies, so consumers must additionally connect
-# downsamplerN.output_2 -> stabilizer.file_nameN (see the 3-cam suppressor /
-# tracker / utility pipes).
-#
-# Only n_input is fixed here (structural). Everything else is left at the
-# process defaults so it can be set per run WITHOUT editing this file, via
-#   kwiver runner ... -s stabilizer:<key>=<value>
-# (a value set here would otherwise shadow the command line). Overridable keys:
-#   method       hybrid (default) | metadata
-#   flight_log   FMCLOG CSV or directory of daily logs; empty = image-only
-#                registration (metadata-optional: hybrid works either way)
-#   require_metadata        true (set below) | false. Fail the run if no
-#                flight_log metadata file is provided. Set false to allow
-#                image-only registration.
-#   require_metadata_match  true | false (default). Fail the run if the metadata
-#                does not correspond to the current image sequence.
-#   min_metadata_coverage   0..1 (default 1.0). Fraction of the sequence that the
-#                metadata must cover when require_metadata_match is set.
-#   water_method auto (default) | svm | sift
-#   gps_chain_reconcile true (default) | false -- correct per-frame GPS
-#                positions that disagree with the image chain (sub-second
-#                trigger / GPS-sample aliasing), verified per-step by an
-#                independent image match; false places frames at raw GPS
-#   site_folder  survey folder; empty = derived from image_list1
-#   image_list<i> one line-separated image-list file per camera (image_list1,
-#                image_list2, ...); each defaults to the pipeline input list, and
-#                image_list1's first entry also locates the survey folder.
-#   register_scope list (default) | folder -- register the given frames vs. the
-#                whole survey folder
-#   cache        homography cache file; empty = <site>/.sea_lion_reg_cache.npz
-#
-# The first frame blocks while the whole survey is registered once; the result
-# is cached to disk, so re-runs (and running detector/suppressor/tracker after
-# a filter_register_frames pass) load it instantly.
+# Description: Whole-survey image registration for one camera, geo-anchored to
+# the flight log.
 # =============================================================================
 
 process stabilizer

--- a/configs/add-ons/sea-lion/common_sea_lion_registration_2cam.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_registration_2cam.pipe
@@ -1,50 +1,8 @@
 # =============================================================================
-# Title: Common - Sea Lion Registration 2cam
+# Title: Two-Camera Sea Lion Survey Registration
 #
-# Description: Shared registration module, drop-in replacement for
-# common_sea_lion_stabilizer_2cam.pipe. Instead of frame-to-frame SURF/VXL
-# stabilization (many_image_stabilizer), the homographies come from the newer
-# whole-survey registration (viame.colmap.colmap_registration:
-# affine chains + rig cross-camera consensus + optional GPS/flight-log
-# geo-anchoring). Exposes the same process name (stabilizer) and output ports
-# (homog1/homog2/homog3), so the multicam suppressor / tracker / homography
-# writer downstream are unchanged.
-#
-# The process also needs the per-camera image PATHS to key its precomputed
-# homographies, so consumers must additionally connect
-# downsamplerN.output_2 -> stabilizer.file_nameN (see the 3-cam suppressor /
-# tracker / utility pipes).
-#
-# Only n_input is fixed here (structural). Everything else is left at the
-# process defaults so it can be set per run WITHOUT editing this file, via
-#   kwiver runner ... -s stabilizer:<key>=<value>
-# (a value set here would otherwise shadow the command line). Overridable keys:
-#   method       hybrid (default) | metadata
-#   flight_log   FMCLOG CSV or directory of daily logs; empty = image-only
-#                registration (metadata-optional: hybrid works either way)
-#   require_metadata        true (set below) | false. Fail the run if no
-#                flight_log metadata file is provided. Set false to allow
-#                image-only registration.
-#   require_metadata_match  true | false (default). Fail the run if the metadata
-#                does not correspond to the current image sequence.
-#   min_metadata_coverage   0..1 (default 1.0). Fraction of the sequence that the
-#                metadata must cover when require_metadata_match is set.
-#   water_method auto (default) | svm | sift
-#   gps_chain_reconcile true (default) | false -- correct per-frame GPS
-#                positions that disagree with the image chain (sub-second
-#                trigger / GPS-sample aliasing), verified per-step by an
-#                independent image match; false places frames at raw GPS
-#   site_folder  survey folder; empty = derived from image_list1
-#   image_list<i> one line-separated image-list file per camera (image_list1,
-#                image_list2, ...); each defaults to the pipeline input list, and
-#                image_list1's first entry also locates the survey folder.
-#   register_scope list (default) | folder -- register the given frames vs. the
-#                whole survey folder
-#   cache        homography cache file; empty = <site>/.sea_lion_reg_cache.npz
-#
-# The first frame blocks while the whole survey is registered once; the result
-# is cached to disk, so re-runs (and running detector/suppressor/tracker after
-# a filter_register_frames pass) load it instantly.
+# Description: Whole-survey image registration for two cameras, geo-anchored to
+# the flight log.
 # =============================================================================
 
 process stabilizer

--- a/configs/add-ons/sea-lion/common_sea_lion_registration_3cam.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_registration_3cam.pipe
@@ -1,50 +1,8 @@
 # =============================================================================
-# Title: Common - Sea Lion Registration 3cam
+# Title: Three-Camera Sea Lion Survey Registration
 #
-# Description: Shared registration module, drop-in replacement for
-# common_sea_lion_stabilizer_3cam.pipe. Instead of frame-to-frame SURF/VXL
-# stabilization (many_image_stabilizer), the homographies come from the newer
-# whole-survey registration (viame.colmap.colmap_registration:
-# affine chains + rig cross-camera consensus + optional GPS/flight-log
-# geo-anchoring). Exposes the same process name (stabilizer) and output ports
-# (homog1/homog2/homog3), so the multicam suppressor / tracker / homography
-# writer downstream are unchanged.
-#
-# The process also needs the per-camera image PATHS to key its precomputed
-# homographies, so consumers must additionally connect
-# downsamplerN.output_2 -> stabilizer.file_nameN (see the 3-cam suppressor /
-# tracker / utility pipes).
-#
-# Only n_input is fixed here (structural). Everything else is left at the
-# process defaults so it can be set per run WITHOUT editing this file, via
-#   kwiver runner ... -s stabilizer:<key>=<value>
-# (a value set here would otherwise shadow the command line). Overridable keys:
-#   method       hybrid (default) | metadata
-#   flight_log   FMCLOG CSV or directory of daily logs; empty = image-only
-#                registration (metadata-optional: hybrid works either way)
-#   require_metadata        true (set below) | false. Fail the run if no
-#                flight_log metadata file is provided. Set false to allow
-#                image-only registration.
-#   require_metadata_match  true | false (default). Fail the run if the metadata
-#                does not correspond to the current image sequence.
-#   min_metadata_coverage   0..1 (default 1.0). Fraction of the sequence that the
-#                metadata must cover when require_metadata_match is set.
-#   water_method auto (default) | svm | sift
-#   gps_chain_reconcile true (default) | false -- correct per-frame GPS
-#                positions that disagree with the image chain (sub-second
-#                trigger / GPS-sample aliasing), verified per-step by an
-#                independent image match; false places frames at raw GPS
-#   site_folder  survey folder; empty = derived from image_list1
-#   image_list<i> one line-separated image-list file per camera (image_list1,
-#                image_list2, ...); each defaults to the pipeline input list, and
-#                image_list1's first entry also locates the survey folder.
-#   register_scope list (default) | folder -- register the given frames vs. the
-#                whole survey folder
-#   cache        homography cache file; empty = <site>/.sea_lion_reg_cache.npz
-#
-# The first frame blocks while the whole survey is registered once; the result
-# is cached to disk, so re-runs (and running detector/suppressor/tracker after
-# a filter_register_frames pass) load it instantly.
+# Description: Whole-survey image registration for three cameras, geo-anchored
+# to the flight log.
 # =============================================================================
 
 process stabilizer

--- a/configs/add-ons/sea-lion/common_sea_lion_stabilizer_1cam.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_stabilizer_1cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Common - Sea Lion Stabilizer 1cam
+# Title: One-Camera Sea Lion Stabilizer
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery.
+# Description: Frame-to-frame homography stabilizer for one camera using SURF
+# features.
 # =============================================================================
 
 process stabilizer

--- a/configs/add-ons/sea-lion/common_sea_lion_stabilizer_2cam.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_stabilizer_2cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Common - Sea Lion Stabilizer 2cam
+# Title: Two-Camera Sea Lion Stabilizer
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery.
+# Description: Frame-to-frame homography stabilizer for two cameras using SURF
+# features.
 # =============================================================================
 
 process stabilizer

--- a/configs/add-ons/sea-lion/common_sea_lion_stabilizer_3cam.pipe
+++ b/configs/add-ons/sea-lion/common_sea_lion_stabilizer_3cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Common - Sea Lion Stabilizer 3cam
+# Title: Three-Camera Sea Lion Stabilizer
 #
-# Description: Shared configuration module that can be included by other
-# pipelines. Configured for sea lion survey imagery.
+# Description: Frame-to-frame homography stabilizer for three cameras using SURF
+# features.
 # =============================================================================
 
 process stabilizer

--- a/configs/add-ons/sea-lion/common_three_camera_input.pipe
+++ b/configs/add-ons/sea-lion/common_three_camera_input.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Three-Camera Input
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Image list readers for three cameras; switch the reader type for
+# video input.
 # =============================================================================
 
 process input1

--- a/configs/add-ons/sea-lion/common_three_camera_input_with_downsamplers.pipe
+++ b/configs/add-ons/sea-lion/common_three_camera_input_with_downsamplers.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Three-Camera Input With Downsamplers
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Three-camera input with a 5 fps downsampler per camera.
 # =============================================================================
 
 include common_three_camera_input.pipe

--- a/configs/add-ons/sea-lion/common_two_camera_input.pipe
+++ b/configs/add-ons/sea-lion/common_two_camera_input.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Two-Camera Input
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Image list readers for two cameras; switch the reader type for
+# video input.
 # =============================================================================
 
 process input1

--- a/configs/add-ons/sea-lion/common_two_camera_input_with_downsamplers.pipe
+++ b/configs/add-ons/sea-lion/common_two_camera_input_with_downsamplers.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Two-Camera Input With Downsamplers
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Two-camera input with a 5 fps downsampler per camera.
 # =============================================================================
 
 include common_two_camera_input.pipe

--- a/configs/add-ons/sea-lion/detector_sea_lion_background_classifier.pipe
+++ b/configs/add-ons/sea-lion/detector_sea_lion_background_classifier.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Sea Lion Detection Pipeline
+# Title: Sea Lion Background Frame Classifier
 #
-# Description: Runs object detection pipeline on input imagery. Uses default
-# input with downsampler configuration. Outputs results to
-# computed_detections.csv. Configured for sea lion survey imagery.
+# Description: Labels each whole frame with its background type (e.g. open
+# water, seaweed water) using SVM models over the default descriptor.
 # Input: IMAGE
 # Output: FULL-SIZE-BBOX
 # =============================================================================

--- a/configs/add-ons/sea-lion/detector_sea_lion_deim_six_class.pipe
+++ b/configs/add-ons/sea-lion/detector_sea_lion_deim_six_class.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Sea Lion Detection Pipeline
+# Title: Sea Lion DEIM Six-Class Detector
 #
-# Description: Six-class sea lion life-stage detection on survey imagery using the DEIMv2
-# detector (ONNX) at 640px chips. Produces bounding boxes only. Output
-# categories: bull (B), sub-adult male (S), female (F), juvenile (J), pup (P),
+# Description: DEIMv2 ONNX detector on 640 px chips producing boxes only.
+# Classes: bull (B), sub-adult male (S), female (F), juvenile (J), pup (P),
 # northern fur seal (NFS).
 # Input: IMAGE
 # Output: BBOX

--- a/configs/add-ons/sea-lion/detector_sea_lion_fusion_seven_class.pipe
+++ b/configs/add-ons/sea-lion/detector_sea_lion_fusion_seven_class.pipe
@@ -1,10 +1,9 @@
 # =============================================================================
-# Title: Sea Lion Detection Pipeline
+# Title: Sea Lion Fusion Seven-Class Detector
 #
-# Description: Seven-class sea lion life-stage detection on survey imagery, fusing multiple
-# detectors with weighted box fusion. Produces a segmentation polygon (mask) for most
-# detections. Output categories: bull (B), sub-adult male (S), female (F),
-# juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
+# Description: Weighted box fusion of the DEIMv2 six-class and RF-DETR
+# eight-class detectors, with masks. Classes: bull (B), sub-adult male (S),
+# female (F), juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
 # Input: IMAGE
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sea-lion/detector_sea_lion_fusion_six_class.pipe
+++ b/configs/add-ons/sea-lion/detector_sea_lion_fusion_six_class.pipe
@@ -1,10 +1,10 @@
 # =============================================================================
-# Title: Sea Lion Detection Pipeline
+# Title: Sea Lion Fusion Six-Class Detector
 #
-# Description: Six-class sea lion life-stage detection on survey imagery, fusing multiple
-# detectors with weighted box fusion. Produces a segmentation polygon (mask) for most
-# detections. Output categories: bull (B), sub-adult male (S), female (F),
-# juvenile (J), pup (P), northern fur seal (NFS).
+# Description: Weighted box fusion of the DEIMv2 six-class and RF-DETR
+# eight-class detectors, with masks; dead pup folds into pup. Classes: bull (B),
+# sub-adult male (S), female (F), juvenile (J), pup (P), northern fur seal
+# (NFS).
 # Input: IMAGE
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sea-lion/detector_sea_lion_fusion_two_class.pipe
+++ b/configs/add-ons/sea-lion/detector_sea_lion_fusion_two_class.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Sea Lion Detection Pipeline
+# Title: Sea Lion Fusion Two-Class Detector
 #
-# Description: Two-class sea lion detection on survey imagery, fusing three detectors
-# with weighted box fusion. Produces a segmentation polygon (mask) for most
-# detections. Output categories: non-pup (NP), pup (P).
+# Description: Weighted box fusion of the RF-DETR two-class, DEIMv2 two-class
+# and RF-DETR eight-class detectors, with masks. Classes: non-pup (NP), pup (P).
 # Input: IMAGE
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sea-lion/detector_sea_lion_rf_detr_two_class.pipe
+++ b/configs/add-ons/sea-lion/detector_sea_lion_rf_detr_two_class.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Sea Lion Detection Pipeline
+# Title: Sea Lion RF-DETR Two-Class Detector
 #
-# Description: Two-class sea lion detection on survey imagery using the RF-DETR
-# segmentation detector at 1008px chips. Produces a segmentation polygon
-# (mask) per detection. Output categories: non-pup (NP), pup (P).
+# Description: RF-DETR segmentation detector on 1008 px chips producing boxes
+# with masks. Classes: non-pup (NP), pup (P).
 # Input: IMAGE
 # Output: MASK
 # =============================================================================

--- a/configs/add-ons/sea-lion/filter_compute_tile_mosaics_2-cam.pipe
+++ b/configs/add-ons/sea-lion/filter_compute_tile_mosaics_2-cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Filter - Compute Tile Mosaics 2-cam
+# Title: Two-Camera Tile Mosaic Filter
 #
-# Description: Registers the camera views and composites each time slice into
-# a single tile mosaic image (all cameras warped into camera 1's frame).
+# Description: Registers both camera views and composites each time slice into
+# one mosaic image in camera 1's frame.
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/filter_compute_tile_mosaics_3-cam.pipe
+++ b/configs/add-ons/sea-lion/filter_compute_tile_mosaics_3-cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Filter - Compute Tile Mosaics 3-cam
+# Title: Three-Camera Tile Mosaic Filter
 #
-# Description: Registers the camera views and composites each time slice into
-# a single tile mosaic image (all cameras warped into camera 1's frame).
+# Description: Registers all three camera views and composites each time slice
+# into one mosaic image in camera 1's frame.
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/filter_register_frames.pipe
+++ b/configs/add-ons/sea-lion/filter_register_frames.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Filter - Register Frames
+# Title: Frame Registration Filter
 #
 # Description: Registers frames across the survey and writes a copy of each
-# image, optionally with previously-observed regions blacked out.
+# image, optionally with previously observed regions blacked out.
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/filter_register_frames_2-cam.pipe
+++ b/configs/add-ons/sea-lion/filter_register_frames_2-cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Filter - Register Frames 2-cam
+# Title: Two-Camera Frame Registration Filter
 #
-# Description: Registers frames between multiple camera views and writes a
-# copy of each image, optionally with previously-observed regions blacked out.
+# Description: Registers frames between both camera views and writes a copy of
+# each image, optionally with previously observed regions blacked out.
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/filter_register_frames_3-cam.pipe
+++ b/configs/add-ons/sea-lion/filter_register_frames_3-cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Filter - Register Frames 3-cam
+# Title: Three-Camera Frame Registration Filter
 #
-# Description: Registers frames between multiple camera views and writes a
-# copy of each image, optionally with previously-observed regions blacked out.
+# Description: Registers frames between all three camera views and writes a copy
+# of each image, optionally with previously observed regions blacked out.
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/suppressor_sea_lion_fusion_seven_class_2-cam.pipe
+++ b/configs/add-ons/sea-lion/suppressor_sea_lion_fusion_seven_class_2-cam.pipe
@@ -1,11 +1,10 @@
 # =============================================================================
-# Title: Suppressor - Sea Lion Fusion Seven Class 2-cam
+# Title: Two-Camera Sea Lion Seven-Class Suppressor
 #
-# Description: Marks regions already observed in previous overlapping frames
-# with boxes so the same sea lions are not counted more than once. Configured
-# for sea lion survey imagery. Output categories: bull (B), sub-adult male
-# (S), female (F), juvenile (J), pup (P), northern fur seal (NFS), dead pup
-# (DP).
+# Description: Seven-class fusion detection on both cameras; detections in
+# regions already seen in earlier registered frames are marked Suppressed.
+# Classes: bull (B), sub-adult male (S), female (F), juvenile (J), pup (P),
+# northern fur seal (NFS), dead pup (DP).
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/suppressor_sea_lion_fusion_seven_class_3-cam.pipe
+++ b/configs/add-ons/sea-lion/suppressor_sea_lion_fusion_seven_class_3-cam.pipe
@@ -1,11 +1,10 @@
 # =============================================================================
-# Title: Suppressor - Sea Lion Fusion Seven Class 3-cam
+# Title: Three-Camera Sea Lion Seven-Class Suppressor
 #
-# Description: Marks regions already observed in previous overlapping frames
-# with boxes so the same sea lions are not counted more than once. Configured
-# for sea lion survey imagery. Output categories: bull (B), sub-adult male
-# (S), female (F), juvenile (J), pup (P), northern fur seal (NFS), dead pup
-# (DP).
+# Description: Seven-class fusion detection on all three cameras; detections in
+# regions already seen in earlier registered frames are marked Suppressed.
+# Classes: bull (B), sub-adult male (S), female (F), juvenile (J), pup (P),
+# northern fur seal (NFS), dead pup (DP).
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/suppressor_sea_lion_fusion_two_class_2-cam.pipe
+++ b/configs/add-ons/sea-lion/suppressor_sea_lion_fusion_two_class_2-cam.pipe
@@ -1,9 +1,9 @@
 # =============================================================================
-# Title: Suppressor - Sea Lion Fusion Two Class 2-cam
+# Title: Two-Camera Sea Lion Two-Class Suppressor
 #
-# Description: Marks regions already observed in previous overlapping frames
-# with boxes so the same sea lions are not counted more than once. Configured
-# for sea lion survey imagery. Output categories: non-pup (NP), pup (P).
+# Description: Two-class fusion detection on both cameras; detections in regions
+# already seen in earlier registered frames are marked Suppressed. Classes:
+# non-pup (NP), pup (P).
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/suppressor_sea_lion_fusion_two_class_3-cam.pipe
+++ b/configs/add-ons/sea-lion/suppressor_sea_lion_fusion_two_class_3-cam.pipe
@@ -1,9 +1,9 @@
 # =============================================================================
-# Title: Suppressor - Sea Lion Fusion Two Class 3-cam
+# Title: Three-Camera Sea Lion Two-Class Suppressor
 #
-# Description: Marks regions already observed in previous overlapping frames
-# with boxes so the same sea lions are not counted more than once. Configured
-# for sea lion survey imagery. Output categories: non-pup (NP), pup (P).
+# Description: Two-class fusion detection on all three cameras; detections in
+# regions already seen in earlier registered frames are marked Suppressed.
+# Classes: non-pup (NP), pup (P).
 #
 # Metadata File: stabilizer:flight_log
 #   DIVE binds an optional per-dataset metadata file (e.g. an FMCLOG

--- a/configs/add-ons/sea-lion/tracker_sea_lion_fusion_seven_class_2-cam.pipe
+++ b/configs/add-ons/sea-lion/tracker_sea_lion_fusion_seven_class_2-cam.pipe
@@ -1,11 +1,9 @@
 # =============================================================================
-# Title: Tracker - Sea Lion Fusion Seven Class 2-cam
+# Title: Two-Camera Sea Lion Seven-Class Tracker
 #
-# Description: Runs object tracking on detected objects across video frames,
-# linking detections of the same sea lion from frame to frame so repeat
-# sightings are tied to one individual. Configured for sea lion survey
-# imagery. Output categories: bull (B), sub-adult male (S), female (F),
-# juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
+# Description: Seven-class fusion detection on both cameras, linked across
+# registered frames into tracks. Classes: bull (B), sub-adult male (S), female
+# (F), juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
 # Input: IMAGE
 # Output: TRACK
 #

--- a/configs/add-ons/sea-lion/tracker_sea_lion_fusion_seven_class_3-cam.pipe
+++ b/configs/add-ons/sea-lion/tracker_sea_lion_fusion_seven_class_3-cam.pipe
@@ -1,11 +1,9 @@
 # =============================================================================
-# Title: Tracker - Sea Lion Fusion Seven Class 3-cam
+# Title: Three-Camera Sea Lion Seven-Class Tracker
 #
-# Description: Runs object tracking on detected objects across video frames,
-# linking detections of the same sea lion from frame to frame so repeat
-# sightings are tied to one individual. Configured for sea lion survey
-# imagery. Output categories: bull (B), sub-adult male (S), female (F),
-# juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
+# Description: Seven-class fusion detection on all three cameras, linked across
+# registered frames into tracks. Classes: bull (B), sub-adult male (S), female
+# (F), juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
 # Input: IMAGE
 # Output: TRACK
 #

--- a/configs/add-ons/sea-lion/tracker_sea_lion_fusion_two_class_2-cam.pipe
+++ b/configs/add-ons/sea-lion/tracker_sea_lion_fusion_two_class_2-cam.pipe
@@ -1,10 +1,8 @@
 # =============================================================================
-# Title: Tracker - Sea Lion Fusion Two Class 2-cam
+# Title: Two-Camera Sea Lion Two-Class Tracker
 #
-# Description: Runs object tracking on detected objects across video frames,
-# linking detections of the same sea lion from frame to frame so repeat
-# sightings are tied to one individual. Configured for sea lion survey
-# imagery. Output categories: non-pup (NP), pup (P).
+# Description: Two-class fusion detection on both cameras, linked across
+# registered frames into tracks. Classes: non-pup (NP), pup (P).
 # Input: IMAGE
 # Output: TRACK
 #

--- a/configs/add-ons/sea-lion/tracker_sea_lion_fusion_two_class_3-cam.pipe
+++ b/configs/add-ons/sea-lion/tracker_sea_lion_fusion_two_class_3-cam.pipe
@@ -1,10 +1,8 @@
 # =============================================================================
-# Title: Tracker - Sea Lion Fusion Two Class 3-cam
+# Title: Three-Camera Sea Lion Two-Class Tracker
 #
-# Description: Runs object tracking on detected objects across video frames,
-# linking detections of the same sea lion from frame to frame so repeat
-# sightings are tied to one individual. Configured for sea lion survey
-# imagery. Output categories: non-pup (NP), pup (P).
+# Description: Two-class fusion detection on all three cameras, linked across
+# registered frames into tracks. Classes: non-pup (NP), pup (P).
 # Input: IMAGE
 # Output: TRACK
 #

--- a/configs/add-ons/sea-lion/tracker_sea_lion_suppressor_fusion_seven_class.pipe
+++ b/configs/add-ons/sea-lion/tracker_sea_lion_suppressor_fusion_seven_class.pipe
@@ -1,11 +1,10 @@
 # =============================================================================
-# Title: Tracker - Sea Lion Suppressor Fusion Seven Class
+# Title: Sea Lion Seven-Class Suppressor
 #
-# Description: Runs object tracking on detected objects across video frames,
-# linking detections of the same sea lion from frame to frame so repeat
-# sightings are tied to one individual. Configured for sea lion survey
-# imagery. Output categories: bull (B), sub-adult male (S), female (F),
-# juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
+# Description: Seven-class fusion detection on one camera; detections in regions
+# already seen in earlier registered frames are marked Suppressed. Classes: bull
+# (B), sub-adult male (S), female (F), juvenile (J), pup (P), northern fur seal
+# (NFS), dead pup (DP).
 # Input: IMAGE
 # Output: TRACK
 #

--- a/configs/add-ons/sea-lion/tracker_sea_lion_suppressor_fusion_two_class.pipe
+++ b/configs/add-ons/sea-lion/tracker_sea_lion_suppressor_fusion_two_class.pipe
@@ -1,10 +1,9 @@
 # =============================================================================
-# Title: Tracker - Sea Lion Suppressor Fusion Two Class
+# Title: Sea Lion Two-Class Suppressor
 #
-# Description: Runs object tracking on detected objects across video frames,
-# linking detections of the same sea lion from frame to frame so repeat
-# sightings are tied to one individual. Configured for sea lion survey
-# imagery. Output categories: non-pup (NP), pup (P).
+# Description: Two-class fusion detection on one camera; detections in regions
+# already seen in earlier registered frames are marked Suppressed. Classes:
+# non-pup (NP), pup (P).
 # Input: IMAGE
 # Output: TRACK
 #

--- a/configs/add-ons/sea-lion/tracker_sea_lion_tracker_fusion_seven_class.pipe
+++ b/configs/add-ons/sea-lion/tracker_sea_lion_tracker_fusion_seven_class.pipe
@@ -1,11 +1,9 @@
 # =============================================================================
-# Title: Tracker - Sea Lion Tracker Fusion Seven Class
+# Title: Sea Lion Seven-Class Tracker
 #
-# Description: Runs object tracking on detected objects across video frames,
-# linking detections of the same sea lion from frame to frame so repeat
-# sightings are tied to one individual. Configured for sea lion survey
-# imagery. Output categories: bull (B), sub-adult male (S), female (F),
-# juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
+# Description: Seven-class fusion detection on one camera, linked across
+# registered frames into tracks. Classes: bull (B), sub-adult male (S), female
+# (F), juvenile (J), pup (P), northern fur seal (NFS), dead pup (DP).
 # Input: IMAGE
 # Output: TRACK
 #

--- a/configs/add-ons/sea-lion/tracker_sea_lion_tracker_fusion_two_class.pipe
+++ b/configs/add-ons/sea-lion/tracker_sea_lion_tracker_fusion_two_class.pipe
@@ -1,10 +1,8 @@
 # =============================================================================
-# Title: Tracker - Sea Lion Tracker Fusion Two Class
+# Title: Sea Lion Two-Class Tracker
 #
-# Description: Runs object tracking on detected objects across video frames,
-# linking detections of the same sea lion from frame to frame so repeat
-# sightings are tied to one individual. Configured for sea lion survey
-# imagery. Output categories: non-pup (NP), pup (P).
+# Description: Two-class fusion detection on one camera, linked across
+# registered frames into tracks. Classes: non-pup (NP), pup (P).
 # Input: IMAGE
 # Output: TRACK
 #

--- a/configs/add-ons/sea-lion/utility_remove_dets_in_ignore_regions.pipe
+++ b/configs/add-ons/sea-lion/utility_remove_dets_in_ignore_regions.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Remove detections in regions indicated by fixed type string(s)
+# Title: Remove Detections in Ignore Regions
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Drops detections overlapping Ignore regions and scales the scores
+# of those in Suppressed regions by 0.1. Images are not loaded.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sea-lion/utility_remove_dets_in_ignore_regions_2-cam.pipe
+++ b/configs/add-ons/sea-lion/utility_remove_dets_in_ignore_regions_2-cam.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Remove detections in regions indicated by fixed type string(s)
+# Title: Remove Detections in Ignore Regions (2-Cam)
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Two-camera variant of the ignore-region filter. Writes a
+# detection file per camera.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sea-lion/utility_remove_dets_in_ignore_regions_3-cam.pipe
+++ b/configs/add-ons/sea-lion/utility_remove_dets_in_ignore_regions_3-cam.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Remove detections in regions indicated by fixed type string(s)
+# Title: Remove Detections in Ignore Regions (3-Cam)
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Three-camera variant of the ignore-region filter. Writes a
+# detection file per camera.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/sea-lion/utility_suppress_water_detections.pipe
+++ b/configs/add-ons/sea-lion/utility_suppress_water_detections.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Sea Lion Water Suppression
+# Title: Suppress Detections in Water Frames
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Classifies each frame's background, then drops detections in
+# open-water frames and halves the scores of those in seaweed-water frames.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/seagis/measurement_from_annotations_seagis.pipe
+++ b/configs/add-ons/seagis/measurement_from_annotations_seagis.pipe
@@ -1,14 +1,10 @@
 # =============================================================================
-# Title: Measurement from annotations pipeline (SEAGIS)
+# Title: SEAGIS Measurement from Annotations
 #
-# Description: Computes stereo measurements from annotated tracks using the
-# SEAGIS StereoLibLX library with .CamCAL calibration files. Reads left and
-# right camera annotations, pairs detections by track ID, and triangulates
-# head/tail keypoints. Epipolar template matching is used as fallback when
-# only one camera has keypoints.
-#
-# Requires: SEAGIS .CamCAL calibration files for left and right cameras.
-#
+# Description: Pairs left and right track annotations by track ID and
+# triangulates head/tail keypoints with the SEAGIS StereoLibLX library from
+# .CamCAL files. Epipolar template matching fills in when only one camera has
+# keypoints.
 # Requires Calibration: True
 # =============================================================================
 

--- a/configs/add-ons/siammask/common_short_term_tracker.pipe
+++ b/configs/add-ons/siammask/common_short_term_tracker.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Common - Short Term Tracker
+# Title: SiamRPN Fish Short-Term Tracker
 #
-# Description: This is a version of SiamRPN++ implemented in pytorch with the
-# siammask library. Uses model: pysot_fish_siamrpn.pt.
+# Description: Short-term tracker running the SiamRPN++ fish model.
 # =============================================================================
 
 process short_term_tracker

--- a/configs/add-ons/siammask/embedded_dual_stream/track_user_selections_fast.pipe
+++ b/configs/add-ons/siammask/embedded_dual_stream/track_user_selections_fast.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Track User Selections Fast
+# Title: Embedded Fast User Selection Tracker
 #
-# Description: Pipeline configuration file.
+# Description: Embedded dual-stream SiamRPN++ short-term tracker extending
+# user-selected detections into tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/siammask/embedded_single_stream/track_user_selections_fast.pipe
+++ b/configs/add-ons/siammask/embedded_single_stream/track_user_selections_fast.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Track User Selections Fast
+# Title: Embedded Fast User Selection Tracker
 #
-# Description: Pipeline configuration file.
+# Description: Embedded SiamRPN++ short-term tracker extending user-initialized
+# tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/siammask/embedded_single_stream/track_user_selections_fusion.pipe
+++ b/configs/add-ons/siammask/embedded_single_stream/track_user_selections_fusion.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Track User Selections Fusion
+# Title: Embedded Fusion User Selection Tracker
 #
-# Description: Pipeline configuration file.
+# Description: Embedded SiamRPN++ short-term tracker combined with an MDNet
+# mid-term tracker under a track conductor.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/siammask/utility_track_selections_default_mask.pipe
+++ b/configs/add-ons/siammask/utility_track_selections_default_mask.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Example simple tracker pipeline
+# Title: Track User Selections With SiamMask
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Extends user-selected boxes into tracks with masks using
+# SiamMask, merging in existing tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/siammask/utility_track_selections_fish_box_only.pipe
+++ b/configs/add-ons/siammask/utility_track_selections_fish_box_only.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Example simple tracker pipeline
+# Title: Track User Selections With SiamRPN Fish Model
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Extends user-selected boxes into box-only tracks with the
+# SiamRPN++ fish model, merging in existing tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/add-ons/srnn/common_default_tracker.pipe
+++ b/configs/add-ons/srnn/common_default_tracker.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Common - Default Tracker
+# Title: Default SRNN Tracker
 #
-# Description: Current incumbent is a modified version of "Tracking the
-# Untrackable" implemented in pytorch, trained on assorted fish data. Uses
-# model: rnn_ml_aim.pt.
+# Description: Tracking-the-Untrackable style SRNN tracker using Siamese
+# appearance features and RNN association with IoU gating.
 # =============================================================================
 
 process tracker

--- a/configs/add-ons/uw-fish/detector_matlab_camtrawl.pipe
+++ b/configs/add-ons/uw-fish/detector_matlab_camtrawl.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Matlab Camtrawl detector pipeline
+# Title: Matlab Camtrawl Detector
 #
-# Description: Matlab Camtrawl detector pipeline
+# Description: Matlab GMM background-subtraction detector. The classifier and
+# drawing stages are commented out and no detections are written.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/pipelines/common_default_descriptor.cpu.pipe
+++ b/configs/pipelines/common_default_descriptor.cpu.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Common - Default Descriptor.cpu
+# Title: Default Descriptor (CPU)
 #
-# Description: Current incumbent is the last layer of the EfficientNet_V2_S.
-# Uses model: pytorch_efficientnet_v2_s.pt.
+# Description: EfficientNet_V2_S appearance descriptor run on the CPU.
 # =============================================================================
 
 process descriptor

--- a/configs/pipelines/common_default_descriptor.pipe
+++ b/configs/pipelines/common_default_descriptor.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: Common - Default Descriptor
+# Title: Default Descriptor
 #
-# Description: Current incumbent is the last layer of the EfficientNet_V2_S.
-# Uses model: pytorch_efficientnet_v2_s.pt.
+# Description: EfficientNet_V2_S appearance descriptor run on the GPU.
 # =============================================================================
 
 process descriptor

--- a/configs/pipelines/common_default_initializer.pipe
+++ b/configs/pipelines/common_default_initializer.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Common - Default Initializer
+# Title: Default Track Initializer
 #
-# Description: Current incumbent is just a straight-up threshold on detection
-# scores.
+# Description: Starts a track from every detection above a fixed score
+# threshold.
 # =============================================================================
 
 process track_initializer

--- a/configs/pipelines/common_default_input.pipe
+++ b/configs/pipelines/common_default_input.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Default Input
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Image list reader forcing 8-bit frames; switch the reader type
+# for video input.
 # =============================================================================
 
 process input

--- a/configs/pipelines/common_default_input_16bit.pipe
+++ b/configs/pipelines/common_default_input_16bit.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Default input for 16-bit or floating point imagery
+# Title: Default Input (16-bit)
 #
-# Description: By default, this is an image list reader that preserves the
-# original bit depth (does not force 8-bit conversion). This can be over-riden
-# by changing :video_reader:type to be vidl_ffmpeg for videos.
+# Description: Image list reader that preserves the original bit depth instead
+# of forcing 8-bit; switch the reader type for video input.
 # =============================================================================
 
 process input

--- a/configs/pipelines/common_default_input_with_downsampler.pipe
+++ b/configs/pipelines/common_default_input_with_downsampler.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Default Input with Downsampler
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Default input plus a 5 fps downsampler.
 # =============================================================================
 
 include common_default_input.pipe

--- a/configs/pipelines/common_default_tracker.pipe
+++ b/configs/pipelines/common_default_tracker.pipe
@@ -1,10 +1,8 @@
 # =============================================================================
-# Title: Common - Default Tracker
+# Title: Default ByteTrack Tracker
 #
-# Description: Default multi-object tracker using ByteTrack algorithm. ByteTrack
-# is a simple and effective tracker that associates detections using IoU-based
-# matching with a two-stage association strategy for high and low confidence
-# detections.
+# Description: ByteTrack tracker process: two-stage IoU association with a
+# Kalman motion model.
 # =============================================================================
 
 process tracker

--- a/configs/pipelines/common_empty_tracker.pipe
+++ b/configs/pipelines/common_empty_tracker.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Common - Empty Tracker
+# Title: Empty Tracker
 #
-# Description: Produces an empty object_track_set for each frame. Useful when
-# a downstream process (e.g. refine_tracks) requires an object_track_set input
-# but no upstream detector is present.
+# Description: Emits an empty track set per frame for pipelines that need a
+# track input but have no detector upstream.
 #
 # Inputs:  downsampler.output_1, downsampler.timestamp
 # Outputs: empty_tracker.object_track_set

--- a/configs/pipelines/common_image_stabilizer.pipe
+++ b/configs/pipelines/common_image_stabilizer.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Based on Kwiver's stabilize_images.pipe
+# Title: Image Stabilizer
 #
-# Description: Based on Kwiver's stabilize_images.pipe
+# Description: SURF-based image stabilizer producing a frame-to-reference
+# homography.
 # =============================================================================
 
 process stabilizer

--- a/configs/pipelines/common_no_load_input.pipe
+++ b/configs/pipelines/common_no_load_input.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: No-Load Input
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Image list reader with image loading disabled; emits only file
+# names and frame times.
 # =============================================================================
 
 process input

--- a/configs/pipelines/common_no_load_input_with_downsampler.pipe
+++ b/configs/pipelines/common_no_load_input_with_downsampler.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: No-Load Input with Downsampler
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: No-load input plus a 5 fps downsampler.
 # =============================================================================
 
 include common_no_load_input.pipe

--- a/configs/pipelines/common_stabilized_iou_tracker.pipe
+++ b/configs/pipelines/common_stabilized_iou_tracker.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Pipeline nodes
+# Title: Stabilized IoU Tracker
 #
-# Description: Shared tracker configuration that can be included by other
-# pipelines.
+# Description: Image stabilizer plus an IoU tracker that links detections in the
+# stabilized frame.
 # =============================================================================
 
 include common_image_stabilizer.pipe

--- a/configs/pipelines/common_stereo_input_with_downsampler.pipe
+++ b/configs/pipelines/common_stereo_input_with_downsampler.pipe
@@ -1,8 +1,7 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Stereo Input with Downsampler
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Two-camera input plus a shared downsampler.
 # =============================================================================
 
 include common_two_cam_input.pipe

--- a/configs/pipelines/common_stereo_input_with_tracks.pipe
+++ b/configs/pipelines/common_stereo_input_with_tracks.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Commonly used stereo input files source with included track inputs as well
+# Title: Stereo Input with Track Readers
 #
-# Description: Commonly used stereo input files source with included track
-# inputs as well Outputs to [INSERT_ME].
+# Description: Downsampled stereo input plus one VIAME CSV track reader per
+# camera.
 # =============================================================================
 
 include common_stereo_input_with_downsampler.pipe

--- a/configs/pipelines/common_three_cam_input.pipe
+++ b/configs/pipelines/common_three_cam_input.pipe
@@ -1,10 +1,8 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Three-Camera Input
 #
-# Description: Three-camera input trio (input1/input2/input3), the 3-camera
-# counterpart to common_two_cam_input.pipe. By default these are image list
-# readers, but this can be over-riden by changing :video_reader:type to be
-# vidl_ffmpeg for videos
+# Description: Image list readers for three cameras; switch the reader type for
+# video input.
 # =============================================================================
 
 process input1

--- a/configs/pipelines/common_two_cam_input.pipe
+++ b/configs/pipelines/common_two_cam_input.pipe
@@ -1,10 +1,8 @@
 # =============================================================================
-# Title: :video_reader:type to be vidl_ffmpeg for videos
+# Title: Two-Camera Input
 #
-# Description: Two-camera input pair (input1/input2), shared by the stereo
-# measurement pipelines and the align-cameras utilities. By default these are
-# image list readers, but this can be over-riden by changing
-# :video_reader:type to be vidl_ffmpeg for videos
+# Description: Image list readers for two cameras; switch the reader type for
+# video input.
 # =============================================================================
 
 process input1

--- a/configs/pipelines/database_apply_svm_models.pipe
+++ b/configs/pipelines/database_apply_svm_models.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Detection pipeline with SVM rapid model filters
+# Title: Database SVM Model Applier
 #
-# Description: Pipeline configuration file.
+# Description: Scores one video's database tracks with the user's trained SVM
+# models.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/detector_calibration_target.pipe
+++ b/configs/pipelines/detector_calibration_target.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: OCV target Detector Pipeline
+# Title: Calibration Target Detector
 #
-# Description: Runs automated ocv target detection on image Outputs to
-# computed_detections.csv.
+# Description: Detects chessboard calibration target corners with OpenCV and
+# writes each corner as a detection.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/pipelines/detector_gmm_motion.pipe
+++ b/configs/pipelines/detector_gmm_motion.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Camtrawl detector pipeline
+# Title: GMM Motion Detector
 #
-# Description: Runs camtrawl GMM model on data Outputs to
-# computed_detections.csv.
+# Description: Gaussian mixture background subtraction; moving regions are
+# written as detections.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/pipelines/detector_huggingface_zeroshot.pipe
+++ b/configs/pipelines/detector_huggingface_zeroshot.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: HuggingFace Detector
+# Title: HuggingFace Zero-Shot Detector
 #
-# Description: HuggingFace Detector Outputs to computed_detections.csv.
+# Description: Grounding DINO zero-shot detector over 640x640 chips; the prompt
+# classes are configurable.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/detector_simple_hough.pipe
+++ b/configs/pipelines/detector_simple_hough.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Simple hough transform example detector
+# Title: Hough Circle Detector
 #
-# Description: Simple hough transform example detector Outputs to
-# computed_detections.csv.
+# Description: Example detector running the OpenCV Hough circle transform on
+# each frame.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/pipelines/display_annotations.pipe
+++ b/configs/pipelines/display_annotations.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Pipe file to display annotations from test data set
+# Title: Annotation Viewer
 #
-# Description: Pipeline configuration file.
+# Description: Draws detections from an example CSV on each frame and shows them
+# in a viewer window.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_dual_stream/local_trained_eo_detector.pipe
+++ b/configs/pipelines/embedded_dual_stream/local_trained_eo_detector.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
 # Title: Local Trained EO Detector
 #
-# Description: Pipeline configuration file.
+# Description: Embedded run of the locally trained detector on the EO stream.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_dual_stream/local_trained_ir_detector.pipe
+++ b/configs/pipelines/embedded_dual_stream/local_trained_ir_detector.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
 # Title: Local Trained IR Detector
 #
-# Description: Pipeline configuration file.
+# Description: Embedded run of the locally trained detector on the IR stream
+# (image2).
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_dual_stream/train_cfrnn_eo.pipe
+++ b/configs/pipelines/embedded_dual_stream/train_cfrnn_eo.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Training - CFRNN EO
+# Title: CFRNN EO Detector Training
 #
-# Description: Training pipeline for model optimization. Uses Cascade R-CNN
-# detection.
+# Description: Embedded NetHarn Cascade R-CNN training on the EO stream,
+# producing an embedded detector.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_dual_stream/train_cfrnn_ir.pipe
+++ b/configs/pipelines/embedded_dual_stream/train_cfrnn_ir.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Training - CFRNN IR
+# Title: CFRNN IR Detector Training
 #
-# Description: Training pipeline for model optimization. Uses Cascade R-CNN
-# detection.
+# Description: Embedded NetHarn Cascade R-CNN training on the IR stream,
+# producing an embedded detector.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/filter_debayer.pipe
+++ b/configs/pipelines/embedded_single_stream/filter_debayer.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Filter - Debayer
+# Title: Embedded Debayer Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Debayers each frame (BG pattern) to 8-bit.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/filter_debayer_and_enhance.pipe
+++ b/configs/pipelines/embedded_single_stream/filter_debayer_and_enhance.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Filter - Debayer And Enhance
+# Title: Embedded Debayer and Enhance Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Debayers each frame, then applies white balance, CLAHE and
+# saturation boost.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/filter_enhance.pipe
+++ b/configs/pipelines/embedded_single_stream/filter_enhance.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Filter - Enhance
+# Title: Embedded Enhance Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Applies white balance, CLAHE and saturation boost to each frame.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_0001fr.pipe
+++ b/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_0001fr.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Generate Empty Frame Lbls 0001fr
+# Title: Empty Frame Labels per Frame
 #
-# Description: Pipeline configuration file.
+# Description: Emits one full-frame 'unannotated_frame' track per frame, marking
+# frames as empty.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_0010fr.pipe
+++ b/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_0010fr.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Generate Empty Frame Lbls 0010fr
+# Title: Empty Frame Labels per 10 Frames
 #
-# Description: Pipeline configuration file.
+# Description: Emits full-frame 'unannotated_sequence' tracks over fixed
+# 10-frame blocks, marking frames as empty.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_0100fr.pipe
+++ b/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_0100fr.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Generate Empty Frame Lbls 0100fr
+# Title: Empty Frame Labels per 100 Frames
 #
-# Description: Pipeline configuration file.
+# Description: Emits full-frame 'unannotated_sequence' tracks over fixed
+# 100-frame blocks, marking frames as empty.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_1000fr.pipe
+++ b/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_1000fr.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Generate Empty Frame Lbls 1000fr
+# Title: Empty Frame Labels per 1000 Frames
 #
-# Description: Pipeline configuration file.
+# Description: Emits full-frame 'unannotated_sequence' tracks over fixed
+# 1000-frame blocks, marking frames as empty.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_auto.pipe
+++ b/configs/pipelines/embedded_single_stream/generate_empty_frame_lbls_auto.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Generate Empty Frame Lbls Auto
+# Title: Empty Frame Labels per Shot
 #
-# Description: Pipeline configuration file.
+# Description: Emits full-frame 'unannotated_sequence' tracks split at shot
+# breaks detected from frame descriptors.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/generic_proposal_detector.pipe
+++ b/configs/pipelines/embedded_single_stream/generic_proposal_detector.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Generic Proposal Detector
+# Title: Embedded Generic Proposal Detector
 #
-# Description: Pipeline configuration file.
+# Description: Generic RF-DETR object proposals plus the default track
+# initializer.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/local_deep_detector.pipe
+++ b/configs/pipelines/embedded_single_stream/local_deep_detector.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Local Deep Detector
+# Title: Embedded Local Deep Detector
 #
-# Description: Pipeline configuration file.
+# Description: Locally trained detector plus the default track initializer.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/local_deep_detector_with_def_tracker.pipe
+++ b/configs/pipelines/embedded_single_stream/local_deep_detector_with_def_tracker.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Local Deep Detector With Def Tracker
+# Title: Embedded Local Deep Detector with ByteTrack
 #
-# Description: Runs object detection pipeline on input imagery. Uses category
-# models/detector configuration.
+# Description: Locally trained detector followed by the default ByteTrack
+# tracker.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/local_deep_detector_with_stab_tracker.pipe
+++ b/configs/pipelines/embedded_single_stream/local_deep_detector_with_stab_tracker.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Local Deep Detector With Stab Tracker
+# Title: Embedded Local Deep Detector with Stabilized Tracker
 #
-# Description: Runs object detection pipeline on input imagery. Uses category
-# models/detector configuration.
+# Description: Locally trained detector followed by the image-stabilized IoU
+# tracker.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/local_svm_frame_classifier.pipe
+++ b/configs/pipelines/embedded_single_stream/local_svm_frame_classifier.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Local SVM Frame Classifier
+# Title: Embedded Local SVM Frame Classifier
 #
-# Description: Pipeline configuration file.
+# Description: Scores each whole frame with the default descriptor and the
+# locally trained SVM models.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/embedded_single_stream/train_deep_detector_cfrnn.pipe
+++ b/configs/pipelines/embedded_single_stream/train_deep_detector_cfrnn.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Training - Deep Detector CFRNN
+# Title: CFRNN Detector Training
 #
-# Description: Runs object detection pipeline on input imagery. Uses Cascade
-# R-CNN detection.
+# Description: Embedded NetHarn Cascade R-CNN training from input tracks,
+# producing an embedded detector.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/filter_debayer.pipe
+++ b/configs/pipelines/filter_debayer.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Filters input images via debayering them and running basic image filtering
+# Title: Debayer Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Debayers each frame (BG pattern) and writes PNG images.
 # Input: IMAGE
 # Output: IMAGE
 # =============================================================================

--- a/configs/pipelines/filter_debayer_and_depth_map.pipe
+++ b/configs/pipelines/filter_debayer_and_depth_map.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Filters input images via debayering them and running basic image filtering
+# Title: Debayer and Stereo Depth Map Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Debayers and enhances side-by-side stereo frames, then writes an
+# SGBM disparity map per frame.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/filter_debayer_and_enhance.pipe
+++ b/configs/pipelines/filter_debayer_and_enhance.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Filters input images via debayering them and running basic image filtering
+# Title: Debayer and Enhance Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Debayers each frame, then applies white balance, CLAHE and
+# saturation boost. Writes PNG images.
 # Input: IMAGE
 # Output: IMAGE
 # =============================================================================

--- a/configs/pipelines/filter_default.pipe
+++ b/configs/pipelines/filter_default.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Reads image from an arbitrary input source then dumps them out again
+# Title: Downsample and Rewrite Frames
 #
-# Description: Applies filtering operations to input data.
+# Description: Downsamples to 5 fps, writes the kept frames as images, and
+# renumbers the input track CSV to match.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/filter_draw_dets.pipe
+++ b/configs/pipelines/filter_draw_dets.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Pipe file to write out images with annotations drawn on them
+# Title: Draw Detections Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Draws boxes from a VIAME CSV on each frame and writes the images.
 # Input: IMAGE
 # Output: IMAGE
 # =============================================================================

--- a/configs/pipelines/filter_enhance.pipe
+++ b/configs/pipelines/filter_enhance.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Filters input images via debayering them and running basic image filtering
+# Title: Enhance Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Applies white balance, CLAHE and saturation boost to each frame.
+# Writes PNG images.
 # Input: IMAGE
 # Output: IMAGE
 # =============================================================================

--- a/configs/pipelines/filter_extract_chips.pipe
+++ b/configs/pipelines/filter_extract_chips.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Runs an object detector and dumps chips around detections out of it, for later
+# Title: Detection Chip Extractor
 #
-# Description: Extracts image chips around detected objects.
+# Description: Writes an image chip around each detection read from a VIAME CSV.
 # Input: IMAGE
 # Output: IMAGE
 # =============================================================================

--- a/configs/pipelines/filter_split_and_debayer.pipe
+++ b/configs/pipelines/filter_split_and_debayer.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Filters input images via spltting them, debayering them and lastly enhancement
+# Title: Split, Debayer and Enhance Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Splits side-by-side frames, keeps the left half, debayers and
+# enhances it. Writes PNG images.
 # Input: IMAGE
 # Output: IMAGE
 # =============================================================================

--- a/configs/pipelines/filter_split_left_side.pipe
+++ b/configs/pipelines/filter_split_left_side.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Filters input images via debayering them and running basic image filtering
+# Title: Split Left Side Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Splits side-by-side frames and writes only the left half.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/filter_split_right_side.pipe
+++ b/configs/pipelines/filter_split_right_side.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Filters input images via debayering them and running basic image filtering
+# Title: Split Right Side Filter
 #
-# Description: Applies filtering operations to input data.
+# Description: Splits side-by-side frames and writes only the right half.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/filter_stereo_depth_map.pipe
+++ b/configs/pipelines/filter_stereo_depth_map.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Filters input images via debayering them and running basic image filtering
+# Title: Stereo Depth Map Filter
 #
-# Description: Applies filtering operations to input data. Processes stereo
-# camera image pairs.
+# Description: Splits side-by-side stereo frames and writes an OpenCV disparity
+# map per frame.
 # Input: IMAGE
 # Output: IMAGE
 # =============================================================================

--- a/configs/pipelines/filter_to_kwa.pipe
+++ b/configs/pipelines/filter_to_kwa.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Filters input images via debayering them and running basic image filtering
+# Title: Enhance and Write KW Archive
 #
-# Description: Applies filtering operations to input data.
+# Description: Enhances frames and writes them to a KW archive; the output
+# directory and stream name must be set.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/filter_to_video.pipe
+++ b/configs/pipelines/filter_to_video.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Reads image from an arbitrary input source then dumps them out again
+# Title: Image to Video Encoder
 #
-# Description: Applies filtering operations to input data.
+# Description: Encodes the input frames to an MP4 video with ffmpeg.
 # Input: IMAGE
 # Output: VIDEO
 # =============================================================================

--- a/configs/pipelines/filter_tracks_only.pipe
+++ b/configs/pipelines/filter_tracks_only.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Reads image from an arbitrary input source then dumps them out again
+# Title: Extract Frames with Tracks
 #
-# Description: Applies filtering operations to input data.
+# Description: Writes only frames that contain tracks, with the track CSV
+# renumbered to match.
 # Input: IMAGE
 # Output: IMAGE
 # =============================================================================

--- a/configs/pipelines/frame_classifier_svm.pipe
+++ b/configs/pipelines/frame_classifier_svm.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Detection pipeline with SVM rapid model filters
+# Title: SVM Frame Classifier
 #
-# Description: Pipeline configuration file.
+# Description: Scores each whole frame with the user's trained SVM models over
+# the default descriptor and writes one detection per frame.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/index_existing.pipe
+++ b/configs/pipelines/index_existing.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Ingest image list and detections pipeline via pytorch descriptors pipeline
+# Title: Index Existing Detections
 #
-# Description: Pipeline configuration file.
+# Description: Computes descriptors for detections read from a VIAME CSV and
+# ingests the tracks and descriptors into the database.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/index_frame.pipe
+++ b/configs/pipelines/index_frame.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Ingest image list pipeline via pytorch descriptors pipeline
+# Title: Index Full Frames
 #
-# Description: Pipeline configuration file.
+# Description: Treats each frame as one proposal, computes its descriptor and
+# ingests the tracks and descriptors into the database.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/index_frame.svm.gt_only.pipe
+++ b/configs/pipelines/index_frame.svm.gt_only.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Ingest video pipeline using pytorch descriptors
+# Title: Index Groundtruth for SVM Training
 #
-# Description: Pipeline configuration file.
+# Description: Computes descriptors for groundtruth detections only, writes
+# positive/negative id lists for SVM training and ingests them into the
+# database.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/index_frame.svm.pipe
+++ b/configs/pipelines/index_frame.svm.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Ingest video pipeline using pytorch descriptors
+# Title: Index Frames for SVM Training
 #
-# Description: Pipeline configuration file.
+# Description: Merges groundtruth detections with one unannotated full-frame
+# proposal per image, computes descriptors, writes id lists for SVM training and
+# ingests them into the database.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/measurement_calibrate_cameras_default.pipe
+++ b/configs/pipelines/measurement_calibrate_cameras_default.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
 # Title: Stereo Camera Calibration
 #
-# Description: Estimate calibration matrices from left and right stereo cameras
+# Description: Calibrates a stereo pair from chessboard corners detected in both
+# cameras; the chessboard square size must be set.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/measurement_calibrate_cameras_fast.pipe
+++ b/configs/pipelines/measurement_calibrate_cameras_fast.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Stereo Camera Calibration
+# Title: Fast Stereo Camera Calibration
 #
-# Description: Estimate calibration matrices from left and right stereo cameras
+# Description: Stereo calibration from chessboard corners using at most 25
+# selected frames.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/measurement_compute_rectified_disparity.pipe
+++ b/configs/pipelines/measurement_compute_rectified_disparity.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Rectified stereo disparity
+# Title: Rectified Stereo Disparity
 #
-# Description: Pipeline for measuring object dimensions in imagery.
+# Description: Rectifies each stereo pair with the dataset calibration and
+# writes a 16-bit SGBM disparity map per frame.
 #
 # Requires Calibration: True
 # Calibration Keys: depth_map:computer:ocv_stereo_disparity:calibration_file

--- a/configs/pipelines/measurement_detect_calibration_target.pipe
+++ b/configs/pipelines/measurement_detect_calibration_target.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Stereo track OCV targets
+# Title: Stereo Calibration Target Tracker
 #
-# Description: Runs automated ocv target detection on each of the images of a
-# stereo camera Features: - Auto-detects chessboard grid size from first frame
-# - Outputs detected corners with world coordinates
+# Description: Detects chessboard corners in both cameras (grid size
+# auto-detected) and accumulates them into per-camera tracks.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/pipelines/measurement_from_annotations_default.pipe
+++ b/configs/pipelines/measurement_from_annotations_default.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Measurement from annotations pipeline
+# Title: Default Stereo Measurement from Annotations
 #
-# Description: Default measurement from annotations pipeline.
-# Outputs to computed_tracks.csv.
+# Description: Matches annotated keypoints across the stereo pair by epipolar
+# template matching, triangulates them and writes lengths to the output tracks.
 #
 # Requires Calibration: True
 # =============================================================================

--- a/configs/pipelines/measurement_from_annotations_template.pipe
+++ b/configs/pipelines/measurement_from_annotations_template.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Measurement from annotations pipeline
+# Title: Stereo Measurement from Annotations Template
 #
-# Description: Measurement from annotations pipeline
+# Description: Included by the default measurement-from-annotations pipeline.
+# Matches camera 1 keypoints into camera 2 by epipolar NCC template matching and
+# triangulates them with the calibration file.
 #
 # Requires Calibration: True
 # =============================================================================

--- a/configs/pipelines/measurement_fully_auto_gmm_motion.pipe
+++ b/configs/pipelines/measurement_fully_auto_gmm_motion.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Run simple head-length fish measurement using stereo cameras
+# Title: GMM Motion Stereo Measurement
 #
-# Description: Run simple head-length fish measurement using stereo cameras
-# Outputs to computed_tracks2.csv.
+# Description: GMM motion detection in both cameras, with detections measured by
+# stereo triangulation from the calibration file.
 #
 # Requires Calibration: True
 # =============================================================================

--- a/configs/pipelines/query_and_iqr.pipe
+++ b/configs/pipelines/query_and_iqr.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Query And Iqr
+# Title: SVM Query and IQR
 #
-# Description: Pipeline configuration file.
+# Description: Embedded query handler ranking database descriptors with a
+# histogram-kernel SVM refined from IQR feedback, seeded through an LSH
+# nearest-neighbor index.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/query_and_iqr_adaboost.pipe
+++ b/configs/pipelines/query_and_iqr_adaboost.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Query And Iqr (AdaBoost)
+# Title: AdaBoost Query and IQR
 #
-# Description: Pipeline configuration file for IQR using AdaBoost ranking.
+# Description: Embedded query handler ranking database descriptors with an
+# AdaBoost model refined from IQR feedback. Alternative to the default SVM
+# handler.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/query_augment_image.cpu.pipe
+++ b/configs/pipelines/query_augment_image.cpu.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Query Augment Image.cpu
+# Title: Query Image Augmentation (CPU)
 #
-# Description: Pipeline configuration file.
+# Description: Embedded handler generating extra positive and negative query
+# descriptors from the exemplar image, on the CPU.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/query_augment_image.pipe
+++ b/configs/pipelines/query_augment_image.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Query Augment Image
+# Title: Query Image Augmentation
 #
-# Description: Pipeline configuration file.
+# Description: Embedded handler generating extra positive and negative query
+# descriptors from the exemplar image, on the GPU.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/query_from_track.pipe
+++ b/configs/pipelines/query_from_track.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Query database using tracks from CSV file
+# Title: Query Database from Track CSV
 #
-# Description: Pipeline configuration file.
+# Description: Computes descriptors for tracks read from a CSV, queries the
+# database with them and writes the results as tracks.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/query_retrieval_and_iqr.pipe
+++ b/configs/pipelines/query_retrieval_and_iqr.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Query Retrieval And Iqr
+# Title: Query Retrieval and IQR
 #
-# Description: Pipeline configuration file.
+# Description: Embedded interactive-search handler: builds exemplar descriptors,
+# starts a similarity query and refines it with IQR feedback.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/query_video_exemplar.pipe
+++ b/configs/pipelines/query_video_exemplar.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
 # Title: Query Video Exemplar
 #
-# Description: Pipeline configuration file.
+# Description: Placeholder embedded pipeline with only input and output
+# adapters; performs no processing.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/register_multimodal_unsync_ocv.pipe
+++ b/configs/pipelines/register_multimodal_unsync_ocv.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Register co-collected optical and thermal imagery
+# Title: Optical-Thermal Image Registration
 #
-# Description: Register co-collected optical and thermal imagery
+# Description: Time-aligns unsynchronized optical and thermal image lists, warps
+# the thermal frame onto the optical one and writes the merged image per optical
+# frame.
 # =============================================================================
 
 # ============================= GLOBAL PROPERTIES =============================

--- a/configs/pipelines/register_using_homographies.pipe
+++ b/configs/pipelines/register_using_homographies.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Default homography-based registration pipeline
+# Title: Homography Frame Registration
 #
-# Description: Pipeline configuration file.
+# Description: Tracks SURF features across frames and writes each frame's
+# source-to-reference homography.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_default.pipe
+++ b/configs/pipelines/templates/detector_default.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
 # Title: Default Detector Template
 #
-# Description: Runs object detection pipeline on input imagery from disk
+# Description: Standalone detector template whose detector slot is filled by
+# training. Reads from disk, merges overlapping detections and writes CSV.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_fish_svm.pipe
+++ b/configs/pipelines/templates/detector_fish_svm.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Detector Fish Svm Template
+# Title: Fish SVM Classifier Template
 #
-# Description: Standalone counterpart of embedded_fish_svm.pipe, runnable directly on
-# input imagery from disk.
+# Description: RF-DETR fish detector, default descriptor and trained SVM
+# refiner, run on imagery from disk.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_frame_svm.pipe
+++ b/configs/pipelines/templates/detector_frame_svm.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: SVM Classifier on Top of Full Frame Descriptor
+# Title: SVM Frame Classifier Template
 #
-# Description: SVM Classifier on Top of Full Frame Descriptor Outputs to
-# computed_detections.csv.
+# Description: Scores each whole frame with the default descriptor and trained
+# SVM models. Reads from disk.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_generic_netharn.pipe
+++ b/configs/pipelines/templates/detector_generic_netharn.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Detector Generic Netharn Template
+# Title: Generic Proposal NetHarn Classifier Template
 #
-# Description: Standalone counterpart of embedded_generic_netharn.pipe, runnable directly on
-# input imagery from disk.
+# Description: Generic object proposals reclassified by a trained NetHarn
+# refiner. Reads from disk.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_generic_svm.pipe
+++ b/configs/pipelines/templates/detector_generic_svm.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Detector Generic Svm Template
+# Title: Generic Proposal SVM Classifier Template
 #
-# Description: Standalone counterpart of embedded_generic_svm.pipe, runnable directly on
-# input imagery from disk.
+# Description: Generic RF-DETR proposals, default descriptor and trained SVM
+# refiner. Reads from disk.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_netharn_clfr.pipe
+++ b/configs/pipelines/templates/detector_netharn_clfr.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: NetHarn Full Frame Classifier
+# Title: NetHarn Frame Classifier Template
 #
-# Description: NetHarn Full Frame Classifier Outputs to
-# computed_detections.csv.
+# Description: Trained NetHarn classifier labelling each whole frame. Reads from
+# disk.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_netharn_motion.pipe
+++ b/configs/pipelines/templates/detector_netharn_motion.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Cascade Faster R-CNN Detector with Motion Infusion
+# Title: NetHarn Motion Infusion Detector Template
 #
-# Description: Cascade Faster R-CNN Detector with Motion Infusion Outputs to
-# computed_detections.csv.
+# Description: Trained NetHarn detector on [ variance, grey, variance ]
+# motion-infused input. Reads from disk.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_netharn_wtf.pipe
+++ b/configs/pipelines/templates/detector_netharn_wtf.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Cascade Faster R-CNN Detector with Motion Infusion
+# Title: NetHarn Temporal Features Detector Template
 #
-# Description: Cascade Faster R-CNN Detector with Motion Infusion Outputs to
-# computed_detections.csv.
+# Description: Trained NetHarn detector on enhanced RGB plus a temporal variance
+# channel. Reads from disk.
 # =============================================================================
 
 # Standard image or video input plus downsampler

--- a/configs/pipelines/templates/detector_onnx.pipe
+++ b/configs/pipelines/templates/detector_onnx.pipe
@@ -1,17 +1,9 @@
 # =============================================================================
-# Title: Generic ONNX Detector
+# Title: Generic ONNX Detector Template
 #
-# Description: Runs an object-detection ONNX package on input imagery from
-# disk.  No PyTorch required at inference time — only onnxruntime.
-#
-# Required edit: replace [-MODEL-] with the path to the ONNX package: a
-# directory (or .zip archive) holding a .onnx file and, optionally, a
-# .modelspec.json sidecar describing input size, preprocessing, thresholds,
-# and category names (as emitted by the model's ONNX export step).
-#
-# Optional edits: score_thresh, device (cpu / cuda / cuda:0), and decoder
-# (detr / yolo; blank uses the modelspec default).  nms_thresh only applies
-# to decoders without NMS baked into the graph (e.g. yolo).
+# Description: Runs an ONNX detector with onnxruntime, no PyTorch needed. Point
+# the model slot at an ONNX package (a folder or zip holding the .onnx file and
+# optional model spec). Score threshold, device and decoder are optional.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_rf_detr_all_motion.pipe
+++ b/configs/pipelines/templates/detector_rf_detr_all_motion.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Detector Rf Detr All Motion Template
+# Title: RF-DETR All-Motion Detector Template
 #
-# Description: Standalone counterpart of embedded_rf_detr_all_motion.pipe, runnable directly on
-# input imagery from disk.
+# Description: RF-DETR on a motion-only three-channel stack (flow magnitude,
+# frame difference, temporal variance) matching the all-motion training
+# augmentation. Reads from disk; frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_rf_detr_motion.pipe
+++ b/configs/pipelines/templates/detector_rf_detr_motion.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Detector Rf Detr Motion Template
+# Title: RF-DETR Motion Infusion Detector Template
 #
-# Description: Standalone counterpart of embedded_rf_detr_motion.pipe, runnable directly on
-# input imagery from disk.
+# Description: RF-DETR on grayscale merged with short- and long-window motion
+# channels, matching the double-motion training augmentation. Reads from disk;
+# frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_rf_detr_optical_flow.pipe
+++ b/configs/pipelines/templates/detector_rf_detr_optical_flow.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Detector Rf Detr Optical Flow Template
+# Title: RF-DETR Optical Flow Detector Template
 #
-# Description: Standalone counterpart of embedded_rf_detr_optical_flow.pipe, runnable directly on
-# input imagery from disk.
+# Description: RF-DETR on RGB plus a background-compensated optical-flow
+# channel, matching the optical-flow training augmentation. Reads from disk;
+# frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/detector_rf_detr_optical_flow_adaptive.pipe
+++ b/configs/pipelines/templates/detector_rf_detr_optical_flow_adaptive.pipe
@@ -1,8 +1,9 @@
 # =============================================================================
-# Title: Detector Rf Detr Optical Flow Adaptive Template
+# Title: RF-DETR Adaptive Optical Flow Detector Template
 #
-# Description: Standalone counterpart of embedded_rf_detr_optical_flow_adaptive.pipe, runnable directly on
-# input imagery from disk.
+# Description: As the optical flow template, with adaptive per-frame flow
+# normalization matching the adaptive optical-flow training augmentation. Reads
+# from disk.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/templates/embedded_default.pipe
+++ b/configs/pipelines/templates/embedded_default.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Default Detector Template
+# Title: Default Embedded Detector Template
 #
-# Description: Runs object detection pipeline on input imagery from memory
+# Description: Embedded detector template whose detector slot is filled by
+# training.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_fish_svm.pipe
+++ b/configs/pipelines/templates/embedded_fish_svm.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: ResNet Classifier on Fish Detections
+# Title: Embedded Fish SVM Classifier Template
 #
-# Description: ResNet Classifier on Fish Detections
+# Description: RF-DETR fish detector, default descriptor and trained SVM
+# refiner.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_frame_svm.pipe
+++ b/configs/pipelines/templates/embedded_frame_svm.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: ResNet Classifier
+# Title: Embedded SVM Frame Classifier Template
 #
-# Description: Pipeline configuration file.
+# Description: Scores each whole frame with the default descriptor and trained
+# SVM models.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_generic_netharn.pipe
+++ b/configs/pipelines/templates/embedded_generic_netharn.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Secondary Classifier After Generic Object Proposals
+# Title: Embedded Generic Proposal NetHarn Classifier Template
 #
-# Description: Secondary Classifier After Generic Object Proposals Uses model:
-# generic_detector.weights.
+# Description: Generic object proposals reclassified by a trained NetHarn
+# refiner.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_generic_svm.pipe
+++ b/configs/pipelines/templates/embedded_generic_svm.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: SVM Classifier on Generic Object Proposals
+# Title: Embedded Generic Proposal SVM Classifier Template
 #
-# Description: SVM Classifier on Generic Object Proposals
+# Description: Generic RF-DETR proposals, default descriptor and trained SVM
+# refiner.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_generic_svm_tracker.pipe
+++ b/configs/pipelines/templates/embedded_generic_svm_tracker.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
 # Title: SVM Classifier on Generic Object Proposals, with Tracking
 #
-# Description: The generic-proposal SVM detector plus a trained tracker. The
-# including pipeline connects the tracker's image, timestamp and
-# detected_object_set, as it does for embedded_tracker.pipe.
+# Description: The generic-proposal SVM detector plus a trained tracker, for
+# embedding in other pipelines.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_netharn_clfr.pipe
+++ b/configs/pipelines/templates/embedded_netharn_clfr.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: ResNet Classifier
+# Title: Embedded NetHarn Frame Classifier Template
 #
-# Description: Pipeline configuration file.
+# Description: Trained NetHarn classifier labelling each whole frame.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_netharn_motion.pipe
+++ b/configs/pipelines/templates/embedded_netharn_motion.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Cascade Faster R-CNN Detector with Motion Infusion
+# Title: Embedded NetHarn Motion Infusion Detector Template
 #
-# Description: Cascade Faster R-CNN Detector with Motion Infusion
+# Description: Trained NetHarn detector on [ variance, grey, variance ]
+# motion-infused input.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_netharn_wtf.pipe
+++ b/configs/pipelines/templates/embedded_netharn_wtf.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Cascade Faster R-CNN Detector with Motion Infusion
+# Title: Embedded NetHarn Temporal Features Detector Template
 #
-# Description: Cascade Faster R-CNN Detector with Motion Infusion
+# Description: Trained NetHarn detector on enhanced RGB plus a temporal variance
+# channel.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_rf_detr_all_motion.pipe
+++ b/configs/pipelines/templates/embedded_rf_detr_all_motion.pipe
@@ -1,16 +1,9 @@
 # =============================================================================
-# Title: RF-DETR Detector Template with All-Motion Input (no RGB)
+# Title: Embedded RF-DETR All-Motion Detector Template
 #
-# Description: Runs an RF-DETR detector on a 3-channel motion stack that carries
-# no appearance information at all, matching the channel layout produced by
-# train_aug_all_motion during training:
-#
-#     [ flow_magnitude, frame_difference, temporal_variance ]
-#
-# The three operators and their settings must stay identical to the training
-# augmentation -- a mismatch in channel order, flow scale or frame_separation
-# silently feeds the network a different input distribution than it was trained
-# on. Requires temporally ordered input frames.
+# Description: RF-DETR on a motion-only three-channel stack (flow magnitude,
+# frame difference, temporal variance) matching the all-motion training
+# augmentation. Frames must be in temporal order.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_rf_detr_motion.pipe
+++ b/configs/pipelines/templates/embedded_rf_detr_motion.pipe
@@ -1,10 +1,9 @@
 # =============================================================================
-# Title: RF-DETR Detector Template with Motion Infusion
+# Title: Embedded RF-DETR Motion Infusion Detector Template
 #
-# Description: Runs an RF-DETR detector on motion-infused imagery. The input
-# is converted to grayscale and merged with two temporal-variance motion
-# channels, matching the channel layout produced by train_aug_add_double_motion
-# during training ([ motion@window8, grayscale, motion@window16 ]).
+# Description: RF-DETR on grayscale merged with short- and long-window motion
+# channels, matching the double-motion training augmentation. Frames must be in
+# temporal order.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_rf_detr_optical_flow.pipe
+++ b/configs/pipelines/templates/embedded_rf_detr_optical_flow.pipe
@@ -1,10 +1,9 @@
 # =============================================================================
-# Title: RF-DETR Detector Template with Optical-Flow Infusion
+# Title: Embedded RF-DETR Optical Flow Detector Template
 #
-# Description: Runs an RF-DETR detector on 4-channel imagery -- RGB plus a
-# background-compensated optical-flow magnitude channel, matching the channel
-# layout produced by train_aug_add_optical_flow during training
-# ([ R, G, B, flow_magnitude ]). Requires temporally ordered input frames.
+# Description: RF-DETR on RGB plus a background-compensated optical-flow
+# channel, matching the optical-flow training augmentation. Frames must be in
+# temporal order.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_rf_detr_optical_flow_adaptive.pipe
+++ b/configs/pipelines/templates/embedded_rf_detr_optical_flow_adaptive.pipe
@@ -1,10 +1,8 @@
 # =============================================================================
-# Title: RF-DETR Detector Template with Optical-Flow Infusion
+# Title: Embedded RF-DETR Adaptive Optical Flow Detector Template
 #
-# Description: Runs an RF-DETR detector on 4-channel imagery -- RGB plus a
-# background-compensated optical-flow magnitude channel, matching the channel
-# layout produced by train_aug_add_optical_flow during training
-# ([ R, G, B, flow_magnitude ]). Requires temporally ordered input frames.
+# Description: As the embedded optical flow template, with adaptive per-frame
+# flow normalization matching the adaptive optical-flow training augmentation.
 # =============================================================================
 
 process detector_input

--- a/configs/pipelines/templates/embedded_tracker.pipe
+++ b/configs/pipelines/templates/embedded_tracker.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
 # Title: Trained Tracker
 #
-# Description: A track_objects process carrying the parameters estimated by
-# tracker training. Drop-in for common_default_tracker.pipe: the including
-# pipeline connects image, timestamp and detected_object_set itself.
+# Description: Tracker carrying the parameters estimated by tracker training, a
+# drop-in for the default tracker in embedded pipelines.
 # =============================================================================
 
 process tracker

--- a/configs/pipelines/templates/tracker_generic_svm.pipe
+++ b/configs/pipelines/templates/tracker_generic_svm.pipe
@@ -1,9 +1,9 @@
 # =============================================================================
-# Title: Tracker Generic Svm Template
+# Title: Generic SVM Tracker Template
 #
 # Description: The generic-proposal SVM detector followed by a trained tracker,
-# runnable directly on input imagery from disk. Detector training renders this
-# alongside detector.pipe and tracker training fills in the tracker parameters.
+# runnable directly on imagery from disk. Detector training renders it and
+# tracker training fills in the tracker parameters.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/tracker_calibration_target.pipe
+++ b/configs/pipelines/tracker_calibration_target.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: OCV target Tracker Pipeline
+# Title: Calibration Target Tracker
 #
-# Description: Runs automated ocv target detection on image then generate
-# corners tracks Outputs to computed_tracks.csv.
+# Description: Detects chessboard calibration target corners and accumulates
+# them into per-corner tracks.
 # Input: IMAGE
 # Output: BBOX
 # =============================================================================

--- a/configs/pipelines/train_aug_add_color_freq.pipe
+++ b/configs/pipelines/train_aug_add_color_freq.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Training - Aug Add Color Freq
+# Title: Color Frequency Channel Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Appends a color-frequency channel to each RGB frame.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_add_double_motion.pipe
+++ b/configs/pipelines/train_aug_add_double_motion.pipe
@@ -1,33 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Add Double Motion
+# Title: Double Motion Channel Augmentation
 #
-# Description: Source-driven augmentation that reads directly from the
-# common_default_input source. Because that source is a video_input, the same pipeline handles
-# both videos (video_reader:type = vidl_ffmpeg) and image sequences
-# (video_reader:type = image_list) -- the viame train tool selects the reader
-# per input. The frames are downsampled, augmented with two temporal-variance
-# motion channels, and written out in a single pass, so a video is decoded only
-# once and only the augmented frames are written (no intermediate raw-frame
-# dump). Requires temporally ordered input frames.
-#
-# Channel layout is [ variance(window 5), grey, variance(window 30) ]. The two
-# windows are a short one, whose running mean adapts fast enough to track the
-# scene and so responds mainly to abrupt motion, and a long one, whose mean is a
-# stable background model and so accumulates slow, low-contrast motion.
-#
-# The window sizes only started doing anything once vxl_average was fixed to pass
-# window_size through to the averager (it previously hardcoded 20, so the old 8
-# and 16 here produced the SAME image, differing only by the byte scale factor --
-# ch2 was literally round(3 * ch0), correlation 0.9985). Keep the two windows far
-# apart; adjacent values buy nothing. Note that even at 5 vs 30 the two channels
-# still correlate at ~0.85, because they are the same operator at two horizons --
-# train_aug_all_motion.pipe uses three different operators and gets 0.11-0.29.
-#
-# The train tool drives this via 'kwiver runner' with -s overrides for
-# input:video_filename, input:video_reader:type, downsampler:target_frame_rate
-# and image_writer:file_name_template. The writer names frames purely from the
-# template counter (frame%06d.png) so numbering is identical for video and image
-# inputs and groundtruth association is unchanged.
+# Description: Replaces RGB with [variance(5 frames), grey, variance(30
+# frames)]. Frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_add_motion.pipe
+++ b/configs/pipelines/train_aug_add_motion.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Add Motion
+# Title: Motion Channel Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Appends a 20-frame temporal-variance channel to each RGB frame:
+# [R, G, B, motion]. Frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_add_motion_and_color_freq.pipe
+++ b/configs/pipelines/train_aug_add_motion_and_color_freq.pipe
@@ -1,7 +1,9 @@
 # =============================================================================
-# Title: Training - Aug Add Motion And Color Freq
+# Title: Motion and Color Frequency Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Embedded per-image augmenter: random grayscale and hue shift,
+# plus a color-frequency channel and a 20-frame motion variance channel. Frames
+# must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_add_optical_flow.pipe
+++ b/configs/pipelines/train_aug_add_optical_flow.pipe
@@ -1,21 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Add Optical Flow
+# Title: Optical Flow Channel Augmentation
 #
-# Description: Source-driven augmentation that reads directly from the
-# common_default_input source. Because that source is a video_input, the same pipeline handles both
-# videos (video_reader:type = vidl_ffmpeg) and image sequences
-# (video_reader:type = image_list) -- the viame train tool selects the reader
-# per input. The frames are downsampled, augmented with a background-compensated
-# optical-flow magnitude channel appended to RGB (producing a 4-channel RGBA
-# image), and written out in a single pass, so a video is decoded only once and
-# only the augmented frames are written (no intermediate raw-frame dump).
-# Requires temporally ordered input frames.
-#
-# The train tool drives this via 'kwiver runner' with -s overrides for
-# input:video_filename, input:video_reader:type, downsampler:target_frame_rate
-# and image_writer:file_name_template. The writer names frames purely from the
-# template counter (frame%06d.png) so numbering is identical for video and image
-# inputs and groundtruth association is unchanged.
+# Description: Appends a background-compensated optical-flow magnitude channel
+# at a fixed scale: [R, G, B, flow]. Frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_add_optical_flow_adaptive.pipe
+++ b/configs/pipelines/train_aug_add_optical_flow_adaptive.pipe
@@ -1,21 +1,9 @@
 # =============================================================================
-# Title: Training - Aug Add Optical Flow (Adaptive Scaling)
+# Title: Adaptive Optical Flow Channel Augmentation
 #
-# Description: Source-driven augmentation that reads directly from the
-# common_default_input source. Because that source is a video_input, the same pipeline handles both
-# videos (video_reader:type = vidl_ffmpeg) and image sequences
-# (video_reader:type = image_list) -- the viame train tool selects the reader
-# per input. The frames are downsampled, augmented with a background-compensated
-# optical-flow magnitude channel appended to RGB (producing a 4-channel RGBA
-# image), and written out in a single pass, so a video is decoded only once and
-# only the augmented frames are written (no intermediate raw-frame dump).
-# Requires temporally ordered input frames.
-#
-# The train tool drives this via 'kwiver runner' with -s overrides for
-# input:video_filename, input:video_reader:type, downsampler:target_frame_rate
-# and image_writer:file_name_template. The writer names frames purely from the
-# template counter (frame%06d.png) so numbering is identical for video and image
-# inputs and groundtruth association is unchanged.
+# Description: Appends a background-compensated optical-flow magnitude channel
+# scaled per frame to its 99th percentile: [R, G, B, flow]. Frames must be in
+# temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_all_motion.pipe
+++ b/configs/pipelines/train_aug_all_motion.pipe
@@ -1,46 +1,9 @@
 # =============================================================================
-# Title: Training - Aug All Motion (three motion channels, no RGB)
+# Title: All Motion Channel Augmentation
 #
-# Description: Source-driven augmentation that replaces the RGB image entirely
-# with a 3-channel stack of motion representations. Because it reads from the
-# common_default_input source, the same pipeline handles both videos and image
-# sequences in a single pass. Requires temporally ordered input frames.
-#
-# The output channel layout is
-#
-#     [ flow_magnitude, frame_difference, temporal_variance ]
-#
-# Three different operators at three different temporal baselines, rather than
-# one operator at three settings:
-#
-#   1. flow_magnitude    -- dense Farneback optical flow, background-compensated
-#                           (the per-frame median flow vector is subtracted, so
-#                           camera/platform drift cancels). Compares against the
-#                           immediately preceding frame: the shortest baseline,
-#                           and the only channel that measures true displacement
-#                           rather than intensity change.
-#   2. frame_difference  -- symmetric 3-frame differencing at frame_separation 3.
-#                           A wider baseline than flow, and cheap to compute; the
-#                           symmetric form suppresses the ghosting trail that a
-#                           plain 2-frame difference leaves behind a moving
-#                           object.
-#   3. temporal_variance -- squared deviation from a running 20-frame mean. The
-#                           longest baseline: accumulates slow, low-contrast
-#                           motion that a 1- or 3-frame comparison cannot
-#                           separate from sensor noise.
-#
-# Every channel is undirected, so horizontal and vertical flips remain valid
-# augmentations. This is why optical flow is taken as 'magnitude' and not
-# 'vector' (dx,dy): a flip would have to negate dx, which the augmentation layer
-# does not do, and the channel would be silently corrupted.
-#
-# Note the 20-frame variance window is not configurable: vxl_average ignores
-# window_size in window mode and hardcodes 20 (see arrows/vxl/average_frames.cxx,
-# AVERAGER_window constructs windowed_frame_averager with no arguments).
-#
-# The train tool drives this via 'kwiver runner' with -s overrides for
-# input:video_filename, input:video_reader:type, downsampler:target_frame_rate
-# and image_writer:file_name_template.
+# Description: Replaces RGB with three motion channels (flow magnitude, frame
+# difference, temporal variance), matching the all-motion detector templates.
+# Frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_enhance_and_add_motion.pipe
+++ b/configs/pipelines/train_aug_enhance_and_add_motion.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Enhance And Add Motion
+# Title: Enhance and Motion Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Embedded per-image augmenter writing an enhanced RGB image and a
+# separate 20-frame variance motion image. Frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_equalize_via_percentiles.pipe
+++ b/configs/pipelines/train_aug_equalize_via_percentiles.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Percentile Normalization
+# Title: Percentile Normalization Augmentation
 #
-# Description: Training augmentation pipeline that applies percentile-based
-# normalization to convert non-8-bit imagery (16-bit, float, etc.) to 8-bit.
-# Uses the C++ implementation of the equalize_via_percentiles filter.
+# Description: Percentile-based normalization converting non-8-bit imagery
+# (16-bit, float) to 8-bit, using the C++ filter implementation.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_equalize_via_percentiles_npy.pipe
+++ b/configs/pipelines/train_aug_equalize_via_percentiles_npy.pipe
@@ -1,9 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Percentile Normalization (Python/NumPy)
+# Title: Percentile Normalization Augmentation (NumPy)
 #
-# Description: Training augmentation pipeline that applies percentile-based
-# normalization to convert non-8-bit imagery (16-bit, float, etc.) to 8-bit.
-# Uses the Python/NumPy implementation of the equalize_via_percentiles filter.
+# Description: Percentile-based normalization converting non-8-bit imagery
+# (16-bit, float) to 8-bit, using the Python/NumPy filter implementation.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_hue_shifting_only.pipe
+++ b/configs/pipelines/train_aug_hue_shifting_only.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Training - Aug Hue Shifting Only
+# Title: Hue Shift Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Random grayscale and hue shift on each RGB frame.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_intensity_color_freq_motion.pipe
+++ b/configs/pipelines/train_aug_intensity_color_freq_motion.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Intensity Color Freq Motion
+# Title: Intensity, Color Frequency and Motion Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Replaces RGB with grayscale intensity, a color-frequency channel
+# and a 20-frame motion variance channel. Frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_intensity_hue_motion.pipe
+++ b/configs/pipelines/train_aug_intensity_hue_motion.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Intensity Hue Motion
+# Title: Intensity, Hue and Motion Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Replaces RGB with [lightness, hue, motion] from the HLS planes
+# and a 20-frame variance channel. Frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_motion_only.pipe
+++ b/configs/pipelines/train_aug_motion_only.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Motion Only
+# Title: Motion Only Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Replaces each frame with a single 20-frame temporal-variance
+# channel. Frames must be in temporal order.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_split.pipe
+++ b/configs/pipelines/train_aug_split.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Training - Aug Split
+# Title: Split Left Half Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Splits each stitched stereo frame and keeps only the left half.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_split_and_stereo.pipe
+++ b/configs/pipelines/train_aug_split_and_stereo.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Training - Aug Split And Stereo
+# Title: Split and Stereo Disparity Augmentation
 #
-# Description: Training pipeline for model optimization. Processes stereo
-# camera image pairs.
+# Description: Embedded per-image augmenter for stitched stereo pairs: splits
+# the image and appends a disparity map to the left half: [R, G, B, disparity].
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/train_aug_warp_ir_to_eo.pipe
+++ b/configs/pipelines/train_aug_warp_ir_to_eo.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Training - Aug Warp IR To EO
+# Title: Warp IR to EO Augmentation
 #
-# Description: Training pipeline for model optimization.
+# Description: Unimplemented placeholder; the body is a TODO.
 # =============================================================================
 
 TODO: Make me

--- a/configs/pipelines/transcode_compress.pipe
+++ b/configs/pipelines/transcode_compress.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Reads image from an arbitrary input source then dumps them out again
+# Title: Compressed Video Transcode
 #
-# Description: Transcodes input video or images to a different format.
+# Description: Re-encodes input video or images to MP4 at a configurable CRF
+# (default 30).
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/transcode_default.pipe
+++ b/configs/pipelines/transcode_default.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Reads image from an arbitrary input source then dumps them out again
+# Title: Default Video Transcode
 #
-# Description: Transcodes input video or images to a different format.
+# Description: Re-encodes input video or images to MP4 at the downsampled frame
+# rate, with the input tracks resampled to match.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/transcode_draw_dets.pipe
+++ b/configs/pipelines/transcode_draw_dets.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Pipe file to write out images with annotations drawn on them
+# Title: Transcode with Drawn Detections
 #
-# Description: Transcodes input video or images to a different format.
+# Description: Draws detections from a VIAME CSV onto each frame and encodes the
+# result to MP4.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/transcode_enhance.pipe
+++ b/configs/pipelines/transcode_enhance.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Reads image from an arbitrary input source then dumps them out again
+# Title: Enhanced Video Transcode
 #
-# Description: Transcodes input video or images to a different format.
+# Description: Applies white balance, CLAHE and optional smoothing or denoising
+# to each frame and encodes the result to MP4.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/transcode_native_fps.pipe
+++ b/configs/pipelines/transcode_native_fps.pipe
@@ -1,5 +1,5 @@
 # =============================================================================
-# Title: Transcode video at native FPS with upsampled tracks
+# Title: Native FPS Transcode with Track Resampling
 #
 # Description: Reads a video at native frame rate (no downsampling), resamples
 # existing tracks from a downsampled rate to the native rate via bounding box

--- a/configs/pipelines/transcode_tracks_only.pipe
+++ b/configs/pipelines/transcode_tracks_only.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Reads image from an arbitrary input source then dumps them out again
+# Title: Transcode Detected Frames Only
 #
-# Description: Transcodes input video or images to a different format.
+# Description: Encodes only frames that have detections in the input CSV to MP4,
+# renumbering the tracks to match.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/utility_add_head_tail_keypoints_from_dets.pipe
+++ b/configs/pipelines/utility_add_head_tail_keypoints_from_dets.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Add head tail keypoints to existing detections which lack them
+# Title: Add Head-Tail Keypoints from Masks
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Adds head and tail keypoints to detections lacking them by
+# fitting an oriented bounding box to each segmentation mask.
 # Input: MASK
 # Output: HEAD-TAIL
 # =============================================================================

--- a/configs/pipelines/utility_add_segmentations_watershed.pipe
+++ b/configs/pipelines/utility_add_segmentations_watershed.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Add automatically generated segmentations via non-DL methods
+# Title: Watershed Segmentation Generator
 #
-# Description: Adds segmentation masks to existing detections.
+# Description: Generates a mask inside each detection box with OpenCV watershed
+# and writes the mask polygons.
 # Input: BBOX
 # Output: MASK
 # =============================================================================

--- a/configs/pipelines/utility_calibrate_cameras_default_2-cam.pipe
+++ b/configs/pipelines/utility_calibrate_cameras_default_2-cam.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Stereo Camera Calibration
+# Title: Two-Camera Stereo Calibration
 #
-# Description: Estimate calibration matrices from left and right stereo cameras
+# Description: Calibrates a stereo pair from chessboard corners detected in both
+# cameras.
 # =============================================================================
 
 include measurement_calibrate_cameras_default.pipe

--- a/configs/pipelines/utility_calibrate_cameras_fast_2-cam.pipe
+++ b/configs/pipelines/utility_calibrate_cameras_fast_2-cam.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Stereo Camera Calibration
+# Title: Fast Two-Camera Stereo Calibration
 #
-# Description: Estimate calibration matrices from left and right stereo cameras
+# Description: Stereo calibration from chessboard corners using at most 25
+# selected frames.
 # =============================================================================
 
 include measurement_calibrate_cameras_fast.pipe

--- a/configs/pipelines/utility_calibrate_single_camera.pipe
+++ b/configs/pipelines/utility_calibrate_single_camera.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Estimate monocular camera calibration from images of a chessboard target
+# Title: Single Camera Calibration
 #
-# Description: Calibrates camera parameters for measurement.
+# Description: Estimates single-camera intrinsics from chessboard corners in at
+# most 50 frames.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/utility_calibrate_stitched_stereo_pair.pipe
+++ b/configs/pipelines/utility_calibrate_stitched_stereo_pair.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Takes a single video/image input where images are horizontally concatenated
+# Title: Stitched Stereo Pair Calibration
 #
-# Description: Calibrates camera parameters for measurement. Processes stereo
-# camera image pairs.
+# Description: Splits each horizontally concatenated stereo frame, detects
+# chessboard corners in each half and calibrates the pair.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/utility_empty_frame_lbls_auto.pipe
+++ b/configs/pipelines/utility_empty_frame_lbls_auto.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Generate empty per-frame labels with automatic shot break detection
+# Title: Empty Frame Labels with Shot Break Detection
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Creates full-frame 'unannotated_sequence' tracks split at shot
+# breaks detected from frame descriptors.
 # =============================================================================
 
 config _pipeline:_edge

--- a/configs/pipelines/utility_empty_frame_lbls_fixed_interval.pipe
+++ b/configs/pipelines/utility_empty_frame_lbls_fixed_interval.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Generate empty per-frame labels for the entire frame
+# Title: Fixed Interval Empty Frame Labels
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Creates full-frame 'unannotated_sequence' tracks of a fixed
+# length (default 10 frames) covering every frame.
 # Input: IMAGE
 # Output: FULL-SIZE-BBOX
 # =============================================================================

--- a/configs/pipelines/utility_link_detections_default.pipe
+++ b/configs/pipelines/utility_link_detections_default.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Link or re-link detections into tracks using the default tracker
+# Title: Link Detections into Tracks
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Links existing detections into tracks with the default ByteTrack
+# tracker without re-running detection.
 # Input: BBOX
 # Output: TRACK
 # =============================================================================
@@ -25,7 +26,7 @@ connect from downsampler.output_2
         to   detection_reader.image_file_name
 
 # ================================== TRACKER ==================================
-include common_seamap_tracker_v2.5.pipe
+include common_default_tracker.pipe
 
 connect from downsampler.output_1
         to   tracker.image

--- a/configs/pipelines/utility_max_points_per_poly.pipe
+++ b/configs/pipelines/utility_max_points_per_poly.pipe
@@ -1,7 +1,7 @@
 # =============================================================================
-# Title: Set input Detections to contain at most N output polygon points per mask
+# Title: Limit Polygon Points per Mask
 #
-# Description: Utility pipeline for data processing operations.
+# Description: Rewrites each mask polygon to at most N points (default 10).
 # Input: MASK
 # Output: MASK
 # =============================================================================

--- a/configs/pipelines/utility_register_frames.pipe
+++ b/configs/pipelines/utility_register_frames.pipe
@@ -1,7 +1,8 @@
 # =============================================================================
-# Title: Utility - Register Frames
+# Title: Single Camera Frame Registration
 #
-# Description: Registers frames between multiple camera views.
+# Description: Estimates frame-to-reference homographies for one image stream
+# from SURF features and writes them to a homography file.
 # =============================================================================
 
 config _scheduler

--- a/configs/pipelines/utility_register_frames_2-cam.pipe
+++ b/configs/pipelines/utility_register_frames_2-cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Utility - Register Frames 2-cam
+# Title: Two-Camera Frame Registration
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Estimates per-frame homographies for two synchronized camera
+# streams from SURF features and writes one homography file per camera.
 # =============================================================================
 
 config _scheduler

--- a/configs/pipelines/utility_register_frames_3-cam.pipe
+++ b/configs/pipelines/utility_register_frames_3-cam.pipe
@@ -1,8 +1,8 @@
 # =============================================================================
-# Title: Utility - Register Frames 3-cam
+# Title: Three-Camera Frame Registration
 #
-# Description: By default, this is an image list reader, but this can be
-# over-riden by changing :video_reader:type to be vidl_ffmpeg for videos
+# Description: Estimates per-frame homographies for three synchronized camera
+# streams from SURF features and writes one homography file per camera.
 # =============================================================================
 
 config _scheduler

--- a/configs/pipelines/utility_remove_dets_in_ignore_regions.pipe
+++ b/configs/pipelines/utility_remove_dets_in_ignore_regions.pipe
@@ -1,5 +1,5 @@
 # =============================================================================
-# Title: Remove detections falling inside ignore regions
+# Title: Remove Detections in Ignore Regions
 #
 # Description: Drops detections contained in regions labelled ignore, and
 # relabels those only partially inside them as suppressed.

--- a/configs/pipelines/utility_warp_annotations_2-cam.pipe
+++ b/configs/pipelines/utility_warp_annotations_2-cam.pipe
@@ -1,12 +1,8 @@
 # =============================================================================
-# Title: Utility - Warp Camera 2 Annotations onto Camera 1
+# Title: Warp Camera 2 Annotations onto Camera 1
 #
-# Description: Model-free check of the DIVE camera registration hand-off.
-# Reads camera 2's existing annotations and projects them into camera 1's
-# frame using the dataset's registration (DIVE writes it into the job dir
-# and points warp2 at it); camera 2's own annotations pass through
-# unchanged. Camera 1 must be the registration reference (DIVE default
-# display camera).
+# Description: Projects camera 2's annotations into camera 1's frame using the
+# dataset registration. Camera 1 must be the registration reference.
 # Input: IMAGE (per camera), BBOX (per camera)
 # Output: BBOX (per camera)
 # =============================================================================


### PR DESCRIPTION
- Rewrites the `# Title:` / `# Description:` header of every `.pipe` under `configs/pipelines` and `configs/add-ons` (DIVE shows the description in its pipeline picker)
- Replaces placeholder text ("Pipeline configuration file.", "Applies filtering operations to input data.", ...) and titles copied from config keys or section comments
- Plain-language, 1 to 3 lines each; no model filenames, ports, or process names
- Corrects stale facts (GFIT trackers are ByteTrack not SRNN, SAM3 detectors use Grounding DINO, motion template window sizes, left/right mix-ups)
- Only non-comment change: `utility_link_detections_default.pipe` included a nonexistent `common_seamap_tracker_v2.5.pipe`; restored to `common_default_tracker.pipe`