### PR TITLE
Make the align-cameras add-on run under web DIVE

### DIFF
--- a/configs/add-ons/align-cameras/utility_align_cameras_2-cam.pipe
+++ b/configs/add-ons/align-cameras/utility_align_cameras_2-cam.pipe
@@ -7,6 +7,12 @@
 # (format v2) with per-frame observations and quality statistics.
 # =============================================================================
 
+# align_cameras is a Python process. Newer kwiver defaults to the
+# thread_per_process scheduler, which refuses Python processes, so ask
+# for the Python-aware one explicitly like the base pipelines do.
+config _scheduler
+  :type                                        pythread_per_process
+
 config _pipeline:_edge
   :capacity                                    5
 
@@ -48,6 +54,9 @@ process register
   :pairs                                       1-2
   :output_directory                            $CONFIG{global:output_directory}
   :output_json_file                            $CONFIG{global:output_json_file}
+  # Resolved against this file, so the weights are found wherever the
+  # add-on is extracted (web DIVE keeps add-ons outside the install).
+  relativepath weights_path =                 models/minima_loftr.ckpt
   :max_frames                                  12
   :ransac_threshold                            2.0   # DIVE_PARAM["RANSAC threshold (px)", range_float, 0.5, 10, 0.1]
   :min_matches                                 100   # DIVE_PARAM["Min matches per frame", range_int, 4, 1000, 1]

--- a/configs/add-ons/align-cameras/utility_align_cameras_3-cam.pipe
+++ b/configs/add-ons/align-cameras/utility_align_cameras_3-cam.pipe
@@ -10,6 +10,12 @@
 # observations and quality statistics.
 # =============================================================================
 
+# align_cameras is a Python process. Newer kwiver defaults to the
+# thread_per_process scheduler, which refuses Python processes, so ask
+# for the Python-aware one explicitly like the base pipelines do.
+config _scheduler
+  :type                                        pythread_per_process
+
 config _pipeline:_edge
   :capacity                                    5
 
@@ -55,6 +61,9 @@ process register
   :pairs                                       1-2,1-3,2-3
   :output_directory                            $CONFIG{global:output_directory}
   :output_json_file                            $CONFIG{global:output_json_file}
+  # Resolved against this file, so the weights are found wherever the
+  # add-on is extracted (web DIVE keeps add-ons outside the install).
+  relativepath weights_path =                 models/minima_loftr.ckpt
   :max_frames                                  12
   :ransac_threshold                            2.0   # DIVE_PARAM["RANSAC threshold (px)", range_float, 0.5, 10, 0.1]
   :min_matches                                 100   # DIVE_PARAM["Min matches per frame", range_int, 4, 1000, 1]

--- a/plugins/core/align_cameras_process.py
+++ b/plugins/core/align_cameras_process.py
@@ -456,6 +456,10 @@ class AlignCamerasProcess(KwiverProcess):
                 result = alignment_core.register_image_pair(
                     matcher, path_a, path_b, options)
             except Exception as e:
+                # Recorded in the JSON, but say it here too: a missing
+                # checkpoint otherwise only surfaces as a pooled fit with
+                # no usable frames.
+                _log('frame %d/%d: matcher error: %s' % (k + 1, len(kept), e))
                 result = {'success': False, 'code': 'error', 'error': str(e)}
             observation = {
                 'imageLeft': os.path.basename(path_a),


### PR DESCRIPTION
Two things the Desktop install hid.  The web image's newer kwiver defaults to the thread_per_process scheduler, which refuses Python processes, so the pipelines now ask for pythread_per_process the way the base pipelines do.  And the add-on's checkpoint is only searched for under $VIAME_INSTALL, while web DIVE extracts add-ons elsewhere; the pipelines now point at models/minima_loftr.ckpt relative to themselves.

The matcher error for a frame was recorded in the JSON but never printed, so a missing checkpoint looked like "pooled fit failed (insufficient_points)".  Log it per frame.