### PR TITLE
Add robust disparity segment fitting to shared stereo measurement

### DIFF
--- a/configs/add-ons/fdn-stereo/stereo_measure_current_annots_fdn_stereo_s.pipe
+++ b/configs/add-ons/fdn-stereo/stereo_measure_current_annots_fdn_stereo_s.pipe
@@ -49,6 +49,14 @@ process measurer
   :refine_keypoints_with_disparity             true
   :refine_keypoints_disparity_window           7
 
+  # Optional robust profile fit, shared with the SGBM measurement pipeline.
+  # Works with foundation_stereo and fast_foundation_stereo disparity backends.
+  # Invalid samples and outliers must leave >=3 samples and a strict majority.
+  :refine_disparity_segment                    false   # DIVE_PARAM["Robust Segment Fit", bool]
+  :disparity_segment_samples                   11      # DIVE_PARAM["Segment Samples", range_int, 3, 101]
+  :disparity_segment_max_outliers              3       # DIVE_PARAM["Max Invalid or Outlier Samples", range_int, 0, 49]
+  :disparity_segment_max_error                 1.0     # DIVE_PARAM["Max Disparity Residual (px)", range_float, 0.1, 10, 0.1]
+
   # Feature detector configuration (for feature-based methods if needed)
   # Options: ocv_BRISK, ocv_FAST, ocv_GFTT, ocv_ORB, ocv_SIFT, ocv_SURF, etc.
   feature_detector:type                        = ocv_ORB

--- a/configs/add-ons/fdn-stereo/stereo_measure_current_annots_fdn_stereo_s.pipe
+++ b/configs/add-ons/fdn-stereo/stereo_measure_current_annots_fdn_stereo_s.pipe
@@ -49,14 +49,6 @@ process measurer
   :refine_keypoints_with_disparity             true
   :refine_keypoints_disparity_window           7
 
-  # Optional robust profile fit, shared with the SGBM measurement pipeline.
-  # Works with foundation_stereo and fast_foundation_stereo disparity backends.
-  # Invalid samples and outliers must leave >=3 samples and a strict majority.
-  :refine_disparity_segment                    false   # DIVE_PARAM["Robust Segment Fit", bool]
-  :disparity_segment_samples                   11      # DIVE_PARAM["Segment Samples", range_int, 3, 101]
-  :disparity_segment_max_outliers              3       # DIVE_PARAM["Max Invalid or Outlier Samples", range_int, 0, 49]
-  :disparity_segment_max_error                 1.0     # DIVE_PARAM["Max Disparity Residual (px)", range_float, 0.1, 10, 0.1]
-
   # Feature detector configuration (for feature-based methods if needed)
   # Options: ocv_BRISK, ocv_FAST, ocv_GFTT, ocv_ORB, ocv_SIFT, ocv_SURF, etc.
   feature_detector:type                        = ocv_ORB

--- a/configs/pipelines/CMakeLists.txt
+++ b/configs/pipelines/CMakeLists.txt
@@ -233,6 +233,7 @@ if( VIAME_ENABLE_OPENCV )
     stereo_calibrate_cameras_default.pipe
     stereo_calibrate_cameras_fast.pipe
     stereo_compute_rectified_disparity.pipe
+    stereo_measure_current_annots_sgbm.pipe
     stereo_detect_calibration_target.pipe
     register_multimodal_unsync_ocv.pipe
     register_using_homographies.pipe

--- a/configs/pipelines/stereo_measure_current_annots_sgbm.pipe
+++ b/configs/pipelines/stereo_measure_current_annots_sgbm.pipe
@@ -1,0 +1,42 @@
+# =============================================================================
+# Title: Measure current annotations using SGBM disparity
+#
+# Description: Measure head-tail lengths from stereo images and existing
+# annotations using OpenCV SGBM/WLS disparity. Robustly fit disparity along
+# each head-tail segment; reject insufficient or inconsistent samples.
+# Uses the shared measurement, stereo pairing, and length aggregation code.
+#
+# Requires Calibration: True
+# Calibration Keys: measurer:calibration_file
+# =============================================================================
+
+include stereo_measure_current_annots_template.pipe
+
+block measurer
+  :matching_methods                            input_pairs_only,compute_disparity
+  :refine_keypoints_with_disparity              true
+  :refine_disparity_segment                     true    # DIVE_PARAM["Robust Segment Fit", bool]
+  :refine_keypoints_disparity_window            7       # DIVE_PARAM["Disparity Sample Radius", range_int, 0, 30]
+  :disparity_segment_samples                    11      # DIVE_PARAM["Segment Samples", range_int, 3, 101]
+  :disparity_segment_max_outliers               3       # DIVE_PARAM["Max Invalid or Outlier Samples", range_int, 0, 49]
+  :disparity_segment_max_error                  1.0     # DIVE_PARAM["Max Disparity Residual (px)", range_float, 0.1, 10, 0.1]
+  :detection_pairing_method                     disparity_projection
+  :detection_pairing_threshold                  50.0
+  :accumulate_track_pairings                    true
+  :length_aggregation_method                   median
+
+  :stereo_disparity:type                        ocv_stereo_disparity
+  block stereo_disparity:ocv_stereo_disparity
+    :algorithm                                 SGBM
+    :min_disparity                             0
+    :num_disparities                           240
+    :block_size                                11
+    :speckle_window_size                       100
+    :speckle_range                              32
+    :use_wls_filter                            true
+    # compute_measurements supplies rectified images and expects pixel disparity.
+    :compute_depth                             false
+    :output_rectified                          true
+    :output_format                             float32
+  endblock
+endblock

--- a/examples/size_measurement/README.rst
+++ b/examples/size_measurement/README.rst
@@ -395,12 +395,6 @@ the endpoint correspondences, and uses the existing triangulation, stereo track
 pairing, CSV output, and median track-length aggregation. Length units follow
 the calibration translation vector.
 
-The same refinement is available in
-**stereo_measure_current_annots_fdn_stereo_s.pipe** by setting
-``measurer:refine_disparity_segment=true``. It is disabled by default there.
-Other disparity backends can use this option if they return rectified pixel
-disparities; the measurement process supplies the rectified input images.
-
 The default fit uses 11 samples and permits at most 3 invalid or outlier
 samples, with a maximum disparity residual of 1 pixel. These are controlled by
 ``disparity_segment_samples``, ``disparity_segment_max_outliers``, and

--- a/examples/size_measurement/README.rst
+++ b/examples/size_measurement/README.rst
@@ -385,6 +385,35 @@ requiring any manual annotations.
   the field of view.
 
 
+Robust Disparity Segment Measurement
+------------------------------------
+
+**stereo_measure_current_annots_sgbm.pipe** measures existing head-tail
+annotations using OpenCV SGBM/WLS and the shared ``compute_measurements``
+process. It fits a disparity profile along each annotated segment, reconstructs
+the endpoint correspondences, and uses the existing triangulation, stereo track
+pairing, CSV output, and median track-length aggregation. Length units follow
+the calibration translation vector.
+
+The same refinement is available in
+**stereo_measure_current_annots_fdn_stereo_s.pipe** by setting
+``measurer:refine_disparity_segment=true``. It is disabled by default there.
+Other disparity backends can use this option if they return rectified pixel
+disparities; the measurement process supplies the rectified input images.
+
+The default fit uses 11 samples and permits at most 3 invalid or outlier
+samples, with a maximum disparity residual of 1 pixel. These are controlled by
+``disparity_segment_samples``, ``disparity_segment_max_outliers``, and
+``disparity_segment_max_error`` on the measurer. The neighborhood radius for
+each sample is ``refine_keypoints_disparity_window`` (default 7 pixels).
+The fit requires at least three inliers, a strict majority of the requested
+samples, and support spanning at least half the segment. Insufficient support
+skips that measurement; existing valid track measurements remain available
+for aggregation. The model assumes a straight 3D head-tail segment and fits
+in disparity space to account for perspective when its endpoints have
+different depths.
+
+
 .. _Calibration File Format:
 
 Calibration File Format

--- a/plugins/core/CMakeLists.txt
+++ b/plugins/core/CMakeLists.txt
@@ -21,6 +21,7 @@ set( plugin_headers
   full_frame_detector.h
   manipulate_pipelines.h
   measurement_utilities.h
+  disparity_segment.h
   merge_detections_suppress_in_regions.h
   equalize_via_percentiles.h
   pair_stereo_detections.h
@@ -78,6 +79,7 @@ set( plugin_sources
   full_frame_detector.cxx
   manipulate_pipelines.cxx
   measurement_utilities.cxx
+  disparity_segment.cxx
   merge_detections_suppress_in_regions.cxx
   equalize_via_percentiles.cxx
   pair_stereo_detections.cxx

--- a/plugins/core/disparity_segment.cxx
+++ b/plugins/core/disparity_segment.cxx
@@ -1,0 +1,117 @@
+/* This file is part of VIAME, and is distributed under an OSI-approved *
+ * BSD 3-Clause License. See either the root top-level LICENSE file or  *
+ * https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.    */
+
+#include "disparity_segment.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace viame { namespace core {
+
+bool fit_disparity_segment(
+  const std::vector< std::pair< double, double > >& samples,
+  int requested_samples, int max_outliers, double max_error,
+  double& head_disparity, double& tail_disparity )
+{
+  if( requested_samples < 3 || requested_samples > 101 ||
+      max_outliers < 0 || max_outliers >= ( requested_samples + 1 ) / 2 ||
+      requested_samples - max_outliers < 3 ||
+      !std::isfinite( max_error ) || max_error <= 0.0 ||
+      samples.size() > static_cast< size_t >( requested_samples ) )
+  {
+    return false;
+  }
+
+  std::vector< std::pair< double, double > > valid;
+  for( const auto& sample : samples )
+  {
+    if( std::isfinite( sample.first ) && std::isfinite( sample.second ) &&
+        sample.first >= 0.0 && sample.first <= 1.0 && sample.second > 0.0 )
+    {
+      valid.push_back( sample );
+    }
+  }
+  std::sort( valid.begin(), valid.end() );
+  const size_t required = static_cast< size_t >( requested_samples - max_outliers );
+  if( valid.size() < required ) { return false; }
+  for( size_t i = 1; i < valid.size(); ++i )
+  {
+    if( valid[i].first - valid[i-1].first < 1e-9 ) { return false; }
+  }
+
+  // Deterministic two-point consensus; bounded to at most 101 samples.
+  std::vector< size_t > best;
+  double best_error = std::numeric_limits< double >::infinity();
+  for( size_t i = 0; i < valid.size(); ++i )
+  {
+    for( size_t j = i + 1; j < valid.size(); ++j )
+    {
+      const double slope = ( valid[j].second - valid[i].second ) /
+                           ( valid[j].first - valid[i].first );
+      const double intercept = valid[i].second - slope * valid[i].first;
+      std::vector< size_t > inliers;
+      double error = 0.0;
+      for( size_t k = 0; k < valid.size(); ++k )
+      {
+        const double residual = std::abs(
+          valid[k].second - ( intercept + slope * valid[k].first ) );
+        if( residual <= max_error )
+        {
+          inliers.push_back( k );
+          error += residual * residual;
+        }
+      }
+      if( inliers.size() < required ||
+          valid[inliers.back()].first - valid[inliers.front()].first < 0.5 )
+      {
+        continue;
+      }
+      if( inliers.size() > best.size() ||
+          ( inliers.size() == best.size() && error < best_error ) )
+      {
+        best = std::move( inliers );
+        best_error = error;
+      }
+    }
+  }
+  if( best.empty() ) { return false; }
+
+  // Least-squares fit of the consensus in disparity space. Reconstructing
+  // endpoint correspondences lets the existing triangulator handle the rig.
+  double mean_f = 0.0, mean_d = 0.0;
+  for( auto i : best )
+  {
+    mean_f += valid[i].first;
+    mean_d += valid[i].second;
+  }
+  mean_f /= best.size();
+  mean_d /= best.size();
+  double covariance = 0.0, variance = 0.0;
+  for( auto i : best )
+  {
+    const double df = valid[i].first - mean_f;
+    covariance += df * ( valid[i].second - mean_d );
+    variance += df * df;
+  }
+  const double slope = covariance / variance;
+  const double head = mean_d - slope * mean_f;
+  const double tail = head + slope;
+  if( !std::isfinite( head ) || !std::isfinite( tail ) || head <= 0.0 || tail <= 0.0 )
+  {
+    return false;
+  }
+  for( auto i : best )
+  {
+    if( std::abs( valid[i].second - ( head + slope * valid[i].first ) ) > max_error )
+    {
+      return false;
+    }
+  }
+  head_disparity = head;
+  tail_disparity = tail;
+  return true;
+}
+
+} } // namespace viame::core

--- a/plugins/core/disparity_segment.h
+++ b/plugins/core/disparity_segment.h
@@ -1,0 +1,28 @@
+/* This file is part of VIAME, and is distributed under an OSI-approved *
+ * BSD 3-Clause License. See either the root top-level LICENSE file or  *
+ * https://github.com/VIAME/VIAME/blob/main/LICENSE.txt for details.    */
+
+#ifndef VIAME_CORE_DISPARITY_SEGMENT_H
+#define VIAME_CORE_DISPARITY_SEGMENT_H
+
+#include "viame_core_export.h"
+
+#include <utility>
+#include <vector>
+
+namespace viame { namespace core {
+
+/// Fit disparity, not depth, along a rectified image segment. For a straight
+/// 3D segment, disparity is affine in the image interpolation fraction.
+/// Samples are (fraction in [0,1], disparity in pixels). Missing/invalid
+/// samples count against max_outliers, as do residuals exceeding max_error.
+/// Requires a strict majority, at least three inliers, and support spanning
+/// at least half the segment. On failure the output arguments are unchanged.
+VIAME_CORE_EXPORT
+bool fit_disparity_segment(
+  const std::vector< std::pair< double, double > >& samples,
+  int requested_samples, int max_outliers, double max_error,
+  double& head_disparity, double& tail_disparity );
+
+} } // namespace viame::core
+#endif

--- a/plugins/core/measure_objects_process.cxx
+++ b/plugins/core/measure_objects_process.cxx
@@ -272,6 +272,17 @@ measure_objects_process
 
   LOG_INFO( logger(), "Matching methods (in order): " + d->m_settings.matching_methods );
 
+  if( d->m_settings.refine_disparity_segment )
+  {
+#ifndef VIAME_ENABLE_OPENCV
+    throw std::runtime_error( "Segment disparity refinement requires OpenCV rectification" );
+#endif
+    if( !d->m_settings.stereo_depth_map_algorithm )
+    {
+      throw std::runtime_error( "Segment disparity refinement requires stereo_disparity:type" );
+    }
+  }
+
   // Configure utilities from settings
   d->m_utilities.configure( d->m_settings );
 
@@ -725,7 +736,8 @@ measure_objects_process
   // algorithm is configured we can snap each right keypoint to the
   // disparity-implied match of its left counterpart for L/R consistency.
   kv::image_container_sptr refine_disparity;
-  if( d->m_settings.refine_keypoints_with_disparity &&
+  if( ( d->m_settings.refine_keypoints_with_disparity ||
+        d->m_settings.refine_disparity_segment ) &&
       d->m_settings.stereo_depth_map_algorithm &&
       !fully_matched_ids.empty() &&
       input_images.size() >= 2 &&
@@ -759,7 +771,22 @@ measure_objects_process
     bool head_refined = false, tail_refined = false;
     kv::vector_2d refined_head = right_head;
     kv::vector_2d refined_tail = right_tail;
-    if( refine_disparity )
+    if( d->m_settings.refine_disparity_segment )
+    {
+      if( !d->m_utilities.refine_right_segment_with_disparity(
+            refine_disparity, left_head, left_tail, right_cam,
+            refined_head, refined_tail ) )
+      {
+        if( d->m_settings.record_stereo_method )
+        {
+          det1->add_note( ":stereo_method=disparity_segment_rejected" );
+          det2->add_note( ":stereo_method=disparity_segment_rejected" );
+        }
+        continue;
+      }
+      head_refined = tail_refined = true;
+    }
+    else if( refine_disparity )
     {
       const int win = d->m_settings.refine_keypoints_disparity_window;
       refined_head = d->m_utilities.refine_right_point_with_disparity(
@@ -839,6 +866,7 @@ measure_objects_process
       left_cam, right_cam, left_head, right_head, left_tail, right_tail );
 
     const std::string method_tag =
+      d->m_settings.refine_disparity_segment ? "input_kps_disparity_segment" :
       ( head_refined && tail_refined ) ? "input_kps_disparity_refined" :
       ( head_refined || tail_refined ) ? "input_kps_partial_disparity_refined"
                                        : "input_kps_used";
@@ -948,7 +976,8 @@ measure_objects_process
       // object should have similar depths (ratio close to 1.0).
       double max_depth_ratio = d->m_settings.depth_consistency_max_ratio;
 
-      if( max_depth_ratio > 0 && result.head_found && result.tail_found )
+      if( max_depth_ratio > 0 && result.head_found && result.tail_found &&
+          result.method_used != "compute_disparity_segment" )
       {
         auto head_3d = viame::core::triangulate_point(
           left_cam, right_cam, result.left_head, result.right_head );

--- a/plugins/core/measurement_utilities.cxx
+++ b/plugins/core/measurement_utilities.cxx
@@ -13,6 +13,7 @@
 #endif
 
 #include "measurement_utilities.h"
+#include "disparity_segment.h"
 
 #include <vital/algo/algorithm.txx>
 #include <vital/logger/logger.h>
@@ -440,6 +441,10 @@ map_keypoints_to_camera_settings
   , uniqueness_ratio( 0.85 )
   , record_stereo_method( true )
   , refine_keypoints_with_disparity( false )
+  , refine_disparity_segment( false )
+  , disparity_segment_samples( 11 )
+  , disparity_segment_max_outliers( 3 )
+  , disparity_segment_max_error( 1.0 )
   , refine_keypoints_disparity_window( 7 )
   , refine_keypoints_reject_inconsistent( false )
   , refine_keypoints_max_distance( 0.25 )
@@ -632,7 +637,8 @@ map_keypoints_to_camera_settings
     "input_kps_partial_disparity_refined, disparity_inconsistent_rejected, "
     "template_matching, epipolar_template_matching, feature_descriptor, "
     "ransac_feature, depth_projection, external_disparity, or "
-    "compute_disparity." );
+    "compute_disparity, compute_disparity_segment, input_kps_disparity_segment, "
+    "or disparity_segment_rejected." );
 
   config->set_value( "refine_keypoints_with_disparity", refine_keypoints_with_disparity,
     "If true and a stereo_disparity algorithm is configured, snap right "
@@ -641,11 +647,24 @@ map_keypoints_to_camera_settings
     "when disparity is invalid at the query location. Tracks that lacked "
     "a right keypoint are unaffected." );
 
+  config->set_value( "refine_disparity_segment", refine_disparity_segment,
+    "Fit a robust disparity profile along head-tail instead of independently "
+    "sampling endpoints. Requires a stereo_disparity backend and OpenCV "
+    "rectification. Applies to paired tracks and compute_disparity matching. "
+    "Insufficient support skips measurement, without falling back to input "
+    "keypoints. Disabled by default." );
+  config->set_value( "disparity_segment_samples", disparity_segment_samples,
+    "Number of uniformly spaced segment samples (3 to 101)." );
+  config->set_value( "disparity_segment_max_outliers", disparity_segment_max_outliers,
+    "Maximum invalid or rejected segment samples. Must leave at least three "
+    "inliers and a strict majority. Inliers must span at least half the segment." );
+  config->set_value( "disparity_segment_max_error", disparity_segment_max_error,
+    "Maximum disparity residual in pixels for a segment inlier; finite and > 0." );
+
   config->set_value( "refine_keypoints_disparity_window", refine_keypoints_disparity_window,
     "Half-width (in pixels) of the neighborhood sampled when reading the "
     "disparity map for keypoint refinement (median over (2w+1)^2). Set to "
-    "0 for single-pixel lookup. Only applies when "
-    "refine_keypoints_with_disparity is true." );
+    "0 for single-pixel lookup. Also used by refine_disparity_segment." );
 
   config->set_value( "refine_keypoints_reject_inconsistent", refine_keypoints_reject_inconsistent,
     "If true, compare each tracker-provided right keypoint to its "
@@ -768,6 +787,10 @@ map_keypoints_to_camera_settings
   uniqueness_ratio = config->get_value< double >( "uniqueness_ratio", uniqueness_ratio );
   record_stereo_method = config->get_value< bool >( "record_stereo_method", record_stereo_method );
   refine_keypoints_with_disparity = config->get_value< bool >( "refine_keypoints_with_disparity", refine_keypoints_with_disparity );
+  refine_disparity_segment = config->get_value< bool >( "refine_disparity_segment", refine_disparity_segment );
+  disparity_segment_samples = config->get_value< int >( "disparity_segment_samples", disparity_segment_samples );
+  disparity_segment_max_outliers = config->get_value< int >( "disparity_segment_max_outliers", disparity_segment_max_outliers );
+  disparity_segment_max_error = config->get_value< double >( "disparity_segment_max_error", disparity_segment_max_error );
   refine_keypoints_disparity_window = config->get_value< int >( "refine_keypoints_disparity_window", refine_keypoints_disparity_window );
   refine_keypoints_reject_inconsistent = config->get_value< bool >( "refine_keypoints_reject_inconsistent", refine_keypoints_reject_inconsistent );
   refine_keypoints_max_distance = config->get_value< double >( "refine_keypoints_max_distance", refine_keypoints_max_distance );
@@ -927,7 +950,12 @@ map_keypoints_to_camera_settings
 // -----------------------------------------------------------------------------
 map_keypoints_to_camera
 ::map_keypoints_to_camera()
-  : m_default_depth( 5.0 )
+  : m_refine_disparity_segment( false )
+  , m_disparity_segment_samples( 11 )
+  , m_disparity_segment_max_outliers( 3 )
+  , m_disparity_segment_max_error( 1.0 )
+  , m_disparity_segment_window( 7 )
+  , m_default_depth( 5.0 )
   , m_template_size( 31 )
   , m_search_range( 128 )
   , m_template_matching_threshold( 0.2 )
@@ -1115,6 +1143,27 @@ void
 map_keypoints_to_camera
 ::configure( const map_keypoints_to_camera_settings& settings )
 {
+  if( settings.refine_disparity_segment &&
+      ( settings.disparity_segment_samples < 3 ||
+        settings.disparity_segment_samples > 101 ||
+        settings.disparity_segment_max_outliers < 0 ||
+        settings.disparity_segment_max_outliers >=
+          ( settings.disparity_segment_samples + 1 ) / 2 ||
+        settings.disparity_segment_samples - settings.disparity_segment_max_outliers < 3 ||
+        !std::isfinite( settings.disparity_segment_max_error ) ||
+        settings.disparity_segment_max_error <= 0.0 ||
+        settings.refine_keypoints_disparity_window < 0 ) )
+  {
+    throw std::invalid_argument( "Invalid disparity segment settings: require 3..101 "
+      "samples, at least three and a strict majority of inliers, a positive "
+      "finite residual threshold, and a nonnegative sampling window" );
+  }
+  m_refine_disparity_segment = settings.refine_disparity_segment;
+  m_disparity_segment_samples = settings.disparity_segment_samples;
+  m_disparity_segment_max_outliers = settings.disparity_segment_max_outliers;
+  m_disparity_segment_max_error = settings.disparity_segment_max_error;
+  m_disparity_segment_window = settings.refine_keypoints_disparity_window;
+
   set_default_depth( settings.default_depth );
   set_template_params( settings.template_size, settings.search_range,
                        settings.template_matching_threshold,
@@ -2244,10 +2293,19 @@ map_keypoints_to_camera
 
         kv::vector_2d right_head_rect, right_tail_rect;
 
-        head_found = find_corresponding_point_external_disparity(
-          m_cached_compute_disparity, left_head_rect, right_head_rect, 7 );
-        tail_found = find_corresponding_point_external_disparity(
-          m_cached_compute_disparity, left_tail_rect, right_tail_rect, 7 );
+        if( m_refine_disparity_segment )
+        {
+          head_found = tail_found = find_corresponding_segment_external_disparity(
+            m_cached_compute_disparity, left_head_rect, left_tail_rect,
+            right_head_rect, right_tail_rect );
+        }
+        else
+        {
+          head_found = find_corresponding_point_external_disparity(
+            m_cached_compute_disparity, left_head_rect, right_head_rect, 7 );
+          tail_found = find_corresponding_point_external_disparity(
+            m_cached_compute_disparity, left_tail_rect, right_tail_rect, 7 );
+        }
 
         if( head_found || tail_found )
         {
@@ -2256,7 +2314,8 @@ map_keypoints_to_camera
             result.right_head = unrectify_point( right_head_rect, true, right_cam );
           if( tail_found )
             result.right_tail = unrectify_point( right_tail_rect, true, right_cam );
-          result.method_used = "compute_disparity";
+          result.method_used = m_refine_disparity_segment ?
+            "compute_disparity_segment" : "compute_disparity";
         }
         else
         {
@@ -2902,6 +2961,78 @@ map_keypoints_to_camera
 #else
   (void)left_cam; (void)right_cam; (void)left_image; (void)right_image;
   return nullptr;
+#endif
+}
+
+// -----------------------------------------------------------------------------
+bool
+map_keypoints_to_camera
+::find_corresponding_segment_external_disparity(
+  const kv::image_container_sptr& disparity_map,
+  const kv::vector_2d& left_head, const kv::vector_2d& left_tail,
+  kv::vector_2d& right_head, kv::vector_2d& right_tail ) const
+{
+  if( m_disparity_segment_samples < 3 || m_disparity_segment_samples > 101 ||
+      !disparity_map || !left_head.allFinite() || !left_tail.allFinite() ||
+      ( left_tail - left_head ).norm() < m_disparity_segment_samples - 1 )
+  {
+    return false;
+  }
+
+  std::vector< std::pair< double, double > > samples;
+  for( int i = 0; i < m_disparity_segment_samples; ++i )
+  {
+    const double f = static_cast< double >( i ) / ( m_disparity_segment_samples - 1 );
+    const kv::vector_2d point = left_head + f * ( left_tail - left_head );
+    kv::vector_2d match;
+    if( find_corresponding_point_external_disparity(
+          disparity_map, point, match, m_disparity_segment_window ) )
+    {
+      // The existing sampler returns a correspondence at the original
+      // subpixel query coordinate; the disparity remains in pixel units.
+      samples.emplace_back( f, point.x() - match.x() );
+    }
+  }
+  double head_disparity, tail_disparity;
+  if( !fit_disparity_segment( samples, m_disparity_segment_samples,
+        m_disparity_segment_max_outliers, m_disparity_segment_max_error,
+        head_disparity, tail_disparity ) )
+  {
+    return false;
+  }
+  right_head = kv::vector_2d( left_head.x() - head_disparity, left_head.y() );
+  right_tail = kv::vector_2d( left_tail.x() - tail_disparity, left_tail.y() );
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+bool
+map_keypoints_to_camera
+::refine_right_segment_with_disparity(
+  const kv::image_container_sptr& disparity_map,
+  const kv::vector_2d& left_head, const kv::vector_2d& left_tail,
+  const kv::simple_camera_perspective& right_cam,
+  kv::vector_2d& right_head, kv::vector_2d& right_tail ) const
+{
+#ifdef VIAME_ENABLE_OPENCV
+  if( !m_rectification_computed ) { return false; }
+  kv::vector_2d head_rect, tail_rect;
+  if( !find_corresponding_segment_external_disparity(
+        disparity_map, rectify_point( left_head, false ),
+        rectify_point( left_tail, false ), head_rect, tail_rect ) )
+  {
+    return false;
+  }
+  const auto head = unrectify_point( head_rect, true, right_cam );
+  const auto tail = unrectify_point( tail_rect, true, right_cam );
+  if( !head.allFinite() || !tail.allFinite() ) { return false; }
+  right_head = head;
+  right_tail = tail;
+  return true;
+#else
+  (void)disparity_map; (void)left_head; (void)left_tail;
+  (void)right_cam; (void)right_head; (void)right_tail;
+  return false;
 #endif
 }
 

--- a/plugins/core/measurement_utilities.cxx
+++ b/plugins/core/measurement_utilities.cxx
@@ -4073,8 +4073,11 @@ map_keypoints_to_camera
     return false;
   }
 
-  // KWIVER image strides count pixels, so apply them to typed pointers.
-  const void* img_data = img.first_pixel();
+  // Preserve legacy endpoint-sampling behavior for existing pipelines.
+  // Segment refinement opts into correct pixel-to-byte stride conversion.
+  const char* img_data = reinterpret_cast<const char*>( img.first_pixel() );
+  const ptrdiff_t stride_bytes = m_refine_disparity_segment ?
+    static_cast< ptrdiff_t >( img.pixel_traits().num_bytes ) : 1;
 
   // Helper lambda: read disparity at (px, py), returns <= 0 if invalid
   auto read_disparity = [&]( int px, int py ) -> double
@@ -4082,15 +4085,15 @@ map_keypoints_to_camera
     if( img.pixel_traits().type == kv::image_pixel_traits::UNSIGNED &&
         img.pixel_traits().num_bytes == 2 )
     {
-      const uint16_t* ptr = reinterpret_cast<const uint16_t*>( img_data ) +
-        py * img.h_step() + px * img.w_step();
+      const uint16_t* ptr = reinterpret_cast<const uint16_t*>(
+        img_data + ( py * img.h_step() + px * img.w_step() ) * stride_bytes );
       return static_cast< double >( *ptr ) / 256.0;
     }
     else if( img.pixel_traits().type == kv::image_pixel_traits::SIGNED &&
              img.pixel_traits().num_bytes == 2 )
     {
-      const int16_t* ptr = reinterpret_cast<const int16_t*>( img_data ) +
-        py * img.h_step() + px * img.w_step();
+      const int16_t* ptr = reinterpret_cast<const int16_t*>(
+        img_data + ( py * img.h_step() + px * img.w_step() ) * stride_bytes );
       int16_t raw_val = *ptr;
       if( raw_val < 0 )
       {
@@ -4101,8 +4104,8 @@ map_keypoints_to_camera
     else if( img.pixel_traits().type == kv::image_pixel_traits::FLOAT &&
              img.pixel_traits().num_bytes == 4 )
     {
-      const float* ptr = reinterpret_cast<const float*>( img_data ) +
-        py * img.h_step() + px * img.w_step();
+      const float* ptr = reinterpret_cast<const float*>(
+        img_data + ( py * img.h_step() + px * img.w_step() ) * stride_bytes );
       return static_cast< double >( *ptr );
     }
     return -1.0;

--- a/plugins/core/measurement_utilities.cxx
+++ b/plugins/core/measurement_utilities.cxx
@@ -3942,8 +3942,8 @@ map_keypoints_to_camera
     return false;
   }
 
-  // Cast to char* for pointer arithmetic (void* arithmetic is undefined)
-  const char* img_data = reinterpret_cast<const char*>( img.first_pixel() );
+  // KWIVER image strides count pixels, so apply them to typed pointers.
+  const void* img_data = img.first_pixel();
 
   // Helper lambda: read disparity at (px, py), returns <= 0 if invalid
   auto read_disparity = [&]( int px, int py ) -> double
@@ -3951,15 +3951,15 @@ map_keypoints_to_camera
     if( img.pixel_traits().type == kv::image_pixel_traits::UNSIGNED &&
         img.pixel_traits().num_bytes == 2 )
     {
-      const uint16_t* ptr = reinterpret_cast<const uint16_t*>(
-        img_data + py * img.h_step() + px * img.w_step() );
+      const uint16_t* ptr = reinterpret_cast<const uint16_t*>( img_data ) +
+        py * img.h_step() + px * img.w_step();
       return static_cast< double >( *ptr ) / 256.0;
     }
     else if( img.pixel_traits().type == kv::image_pixel_traits::SIGNED &&
              img.pixel_traits().num_bytes == 2 )
     {
-      const int16_t* ptr = reinterpret_cast<const int16_t*>(
-        img_data + py * img.h_step() + px * img.w_step() );
+      const int16_t* ptr = reinterpret_cast<const int16_t*>( img_data ) +
+        py * img.h_step() + px * img.w_step();
       int16_t raw_val = *ptr;
       if( raw_val < 0 )
       {
@@ -3970,8 +3970,8 @@ map_keypoints_to_camera
     else if( img.pixel_traits().type == kv::image_pixel_traits::FLOAT &&
              img.pixel_traits().num_bytes == 4 )
     {
-      const float* ptr = reinterpret_cast<const float*>(
-        img_data + py * img.h_step() + px * img.w_step() );
+      const float* ptr = reinterpret_cast<const float*>( img_data ) +
+        py * img.h_step() + px * img.w_step();
       return static_cast< double >( *ptr );
     }
     return -1.0;

--- a/plugins/core/measurement_utilities.h
+++ b/plugins/core/measurement_utilities.h
@@ -344,6 +344,14 @@ public:
   /// compute_disparity is in matching_methods).
   bool refine_keypoints_with_disparity;
 
+  /// Opt-in robust disparity fit along the entire rectified head-tail segment.
+  /// Applies to already-paired keypoints and the compute_disparity method.
+  /// A failed fit skips measurement instead of falling back to input points.
+  bool refine_disparity_segment;
+  int disparity_segment_samples;
+  int disparity_segment_max_outliers;
+  double disparity_segment_max_error;
+
   /// Half-width (in pixels) of the neighborhood used when sampling the
   /// disparity map for keypoint refinement. The median of valid disparity
   /// values in a (2*w+1)x(2*w+1) window is used. Set to 0 for a
@@ -673,6 +681,21 @@ public:
     int search_window = 7,
     bool* refined = nullptr ) const;
 
+  /// Fit the head-tail disparity profile and unrectify the fitted right
+  /// endpoints. Requires rectification maps; outputs are unchanged on failure.
+  bool refine_right_segment_with_disparity(
+    const kv::image_container_sptr& disparity_map,
+    const kv::vector_2d& left_head, const kv::vector_2d& left_tail,
+    const kv::simple_camera_perspective& right_cam,
+    kv::vector_2d& right_head, kv::vector_2d& right_tail ) const;
+
+  /// Fit a rectified segment using the same disparity formats and median
+  /// neighborhood sampler as single-keypoint refinement. No OpenCV required.
+  bool find_corresponding_segment_external_disparity(
+    const kv::image_container_sptr& disparity_map,
+    const kv::vector_2d& left_head, const kv::vector_2d& left_tail,
+    kv::vector_2d& right_head, kv::vector_2d& right_tail ) const;
+
   /// Get the cached rectified left image (if available)
   /// This returns the rectified left image from the last stereo processing call
   kv::image_container_sptr get_cached_rectified_left() const;
@@ -790,6 +813,11 @@ public:
 
 private:
   // Configuration
+  bool m_refine_disparity_segment;
+  int m_disparity_segment_samples;
+  int m_disparity_segment_max_outliers;
+  double m_disparity_segment_max_error;
+  int m_disparity_segment_window;
   double m_default_depth;
   int m_template_size;
   int m_search_range;

--- a/tests/plugins/core/test_measurement_utilities.cxx
+++ b/tests/plugins/core/test_measurement_utilities.cxx
@@ -901,6 +901,34 @@ TEST_F( measurement_utilities_test, segment_configuration_is_opt_in_and_validate
   EXPECT_NO_THROW( utilities->configure( settings ) );
 }
 
+TEST_F( measurement_utilities_test, segment_sampling_preserves_legacy_defaults )
+{
+  // Existing Foundation Stereo pipelines enable endpoint refinement only.
+  map_keypoints_to_camera_settings settings;
+  settings.refine_keypoints_with_disparity = true;
+  utilities->configure( settings );
+  kv::image_of< float > disparity( 400, 3 );
+  for( unsigned y = 0; y < 3; ++y )
+  {
+    for( unsigned x = 0; x < 400; ++x )
+    {
+      disparity( x, y ) = 125.0 - 0.25 * x;
+    }
+  }
+  auto map = std::make_shared< kv::simple_image_container >( disparity );
+  kv::vector_2d right;
+  ASSERT_TRUE( utilities->find_corresponding_point_external_disparity(
+    map, kv::vector_2d( 100, 1 ), right, 0 ) );
+  // Preserve the pre-existing byte-stride interpretation outside segment mode.
+  EXPECT_DOUBLE_EQ( right.x(), 6.25 );
+
+  settings.refine_disparity_segment = true;
+  utilities->configure( settings );
+  ASSERT_TRUE( utilities->find_corresponding_point_external_disparity(
+    map, kv::vector_2d( 100, 1 ), right, 0 ) );
+  EXPECT_DOUBLE_EQ( right.x(), 0.0 );
+}
+
 TEST_F( measurement_utilities_test, segment_disparity_formats_and_reversed_endpoints )
 {
   map_keypoints_to_camera_settings settings;

--- a/tests/plugins/core/test_measurement_utilities.cxx
+++ b/tests/plugins/core/test_measurement_utilities.cxx
@@ -5,6 +5,10 @@
 #include <gtest/gtest.h>
 
 #include "measurement_utilities.h"
+#include "disparity_segment.h"
+#include <vital/types/image.h>
+#include <vital/types/image_container.h>
+#include <limits>
 
 #include <vital/types/camera_intrinsics.h>
 #include <vital/types/rotation.h>
@@ -782,3 +786,184 @@ TEST( measurement_utilities_static, aggregate_lengths_ignores_invalid_and_empty 
   EXPECT_LT( aggregate_lengths( {}, "average" ), 0.0 );
   EXPECT_LT( aggregate_lengths( { -1.0, 0.0 }, "average" ), 0.0 );
 }
+
+// =============================================================================
+// Robust disparity segment measurement
+// =============================================================================
+namespace {
+std::vector< std::pair< double, double > > segment_samples()
+{
+  std::vector< std::pair< double, double > > samples;
+  for( int i = 0; i < 11; ++i )
+  {
+    const double f = i / 10.0;
+    samples.emplace_back( f, 100.0 - 50.0 * f );
+  }
+  return samples;
+}
+}
+
+TEST( disparity_segment, perspective_correct_endpoints )
+{
+  double head = -1, tail = -1;
+  ASSERT_TRUE( fit_disparity_segment( segment_samples(), 11, 3, 0.1, head, tail ) );
+  EXPECT_NEAR( head, 100.0, 1e-10 );
+  EXPECT_NEAR( tail, 50.0, 1e-10 );
+  // f=1000px, baseline=100mm: endpoints (0,0,1000), (400,0,2000).
+  const kv::vector_3d h( 0, 0, 100000 / head );
+  const kv::vector_3d t( 20000 / tail, 0, 100000 / tail );
+  EXPECT_NEAR( ( t - h ).norm(), std::sqrt( 400.0 * 400 + 1000.0 * 1000 ), 1e-8 );
+}
+
+TEST( disparity_segment, rejects_outliers_and_counts_missing_samples )
+{
+  auto samples = segment_samples();
+  samples[0].second = 500; // foreground contamination
+  samples[5].second = 2;   // background contamination
+  samples.pop_back();     // invalid disparity at the tail
+  double head = -1, tail = -1;
+  ASSERT_TRUE( fit_disparity_segment( samples, 11, 3, 0.1, head, tail ) );
+  EXPECT_NEAR( head, 100, 1e-10 );
+  EXPECT_NEAR( tail, 50, 1e-10 );
+  EXPECT_FALSE( fit_disparity_segment( samples, 11, 2, 0.1, head, tail ) );
+}
+
+TEST( disparity_segment, invalid_data_preserves_outputs )
+{
+  auto samples = segment_samples();
+  for( int i = 0; i < 4; ++i )
+  {
+    samples[i].second = std::numeric_limits< double >::quiet_NaN();
+  }
+  double head = 42, tail = 43;
+  EXPECT_FALSE( fit_disparity_segment( samples, 11, 3, 1, head, tail ) );
+  EXPECT_EQ( head, 42 );
+  EXPECT_EQ( tail, 43 );
+  EXPECT_FALSE( fit_disparity_segment( {}, 11, 3, 1, head, tail ) );
+}
+
+TEST( disparity_segment, validates_configuration )
+{
+  double head = -1, tail = -1;
+  EXPECT_FALSE( fit_disparity_segment( segment_samples(), 2, 0, 1, head, tail ) );
+  EXPECT_FALSE( fit_disparity_segment( segment_samples(), 102, 0, 1, head, tail ) );
+  EXPECT_FALSE( fit_disparity_segment( segment_samples(), 11, 6, 1, head, tail ) );
+  EXPECT_FALSE( fit_disparity_segment( segment_samples(), 11, -1, 1, head, tail ) );
+  EXPECT_FALSE( fit_disparity_segment( segment_samples(), 11, 3, 0, head, tail ) );
+  EXPECT_FALSE( fit_disparity_segment( segment_samples(), 11, 3,
+    std::numeric_limits< double >::infinity(), head, tail ) );
+}
+
+TEST( disparity_segment, rejects_excessive_extrapolation_and_duplicates )
+{
+  auto samples = segment_samples();
+  for( auto& sample : samples ) { sample.first *= 0.4; }
+  double head = -1, tail = -1;
+  EXPECT_FALSE( fit_disparity_segment( samples, 11, 3, 1, head, tail ) );
+  samples = segment_samples();
+  samples[5].first = samples[4].first;
+  EXPECT_FALSE( fit_disparity_segment( samples, 11, 3, 1, head, tail ) );
+}
+
+TEST( disparity_segment, noisy_inliers_are_refit )
+{
+  auto samples = segment_samples();
+  for( size_t i = 0; i < samples.size(); ++i )
+  {
+    samples[i].second += i % 2 ? 0.1 : -0.1;
+  }
+  double head = -1, tail = -1;
+  ASSERT_TRUE( fit_disparity_segment( samples, 11, 3, 0.3, head, tail ) );
+  EXPECT_NEAR( head, 100, 0.1 );
+  EXPECT_NEAR( tail, 50, 0.1 );
+}
+
+TEST( disparity_segment, rejects_nonpositive_fitted_endpoints )
+{
+  auto samples = segment_samples();
+  samples.erase( samples.begin(), samples.begin() + 2 );
+  for( auto& sample : samples ) { sample.second = 100 * sample.first - 10; }
+  double head = -1, tail = -1;
+  EXPECT_FALSE( fit_disparity_segment( samples, 11, 3, 0.1, head, tail ) );
+}
+
+TEST_F( measurement_utilities_test, segment_configuration_is_opt_in_and_validated )
+{
+  map_keypoints_to_camera_settings settings;
+  EXPECT_FALSE( settings.refine_disparity_segment );
+  settings.refine_disparity_segment = true;
+  settings.disparity_segment_samples = 2;
+  EXPECT_THROW( utilities->configure( settings ), std::invalid_argument );
+  settings.disparity_segment_samples = 11;
+  settings.disparity_segment_max_outliers = 6;
+  EXPECT_THROW( utilities->configure( settings ), std::invalid_argument );
+  settings.disparity_segment_max_outliers = 3;
+  EXPECT_NO_THROW( utilities->configure( settings ) );
+}
+
+TEST_F( measurement_utilities_test, segment_disparity_formats_and_reversed_endpoints )
+{
+  map_keypoints_to_camera_settings settings;
+  settings.refine_disparity_segment = true;
+  settings.refine_keypoints_disparity_window = 0;
+  utilities->configure( settings );
+  kv::image_of< float > floats( 400, 3 );
+  kv::image_of< int16_t > raw( 400, 3 );
+  kv::image_of< uint16_t > scaled( 400, 3 );
+  for( unsigned y = 0; y < 3; ++y )
+  {
+    for( unsigned x = 0; x < 400; ++x )
+    {
+      const double d = 125.0 - 0.25 * x;
+      floats( x, y ) = d;
+      raw( x, y ) = d * 16;
+      scaled( x, y ) = d * 256;
+    }
+  }
+  for( const auto& image : std::vector< kv::image >{ floats, raw, scaled } )
+  {
+    auto map = std::make_shared< kv::simple_image_container >( image );
+    kv::vector_2d head, tail;
+    ASSERT_TRUE( utilities->find_corresponding_segment_external_disparity(
+      map, kv::vector_2d( 100, 1 ), kv::vector_2d( 300, 1 ), head, tail ) );
+    EXPECT_NEAR( head.x(), 0, 1e-9 );
+    EXPECT_NEAR( tail.x(), 250, 1e-9 );
+    ASSERT_TRUE( utilities->find_corresponding_segment_external_disparity(
+      map, kv::vector_2d( 300, 1 ), kv::vector_2d( 100, 1 ), tail, head ) );
+    EXPECT_NEAR( head.x(), 0, 1e-9 );
+    EXPECT_NEAR( tail.x(), 250, 1e-9 );
+    EXPECT_FALSE( utilities->find_corresponding_segment_external_disparity(
+      map, kv::vector_2d( 100, 1 ), kv::vector_2d( 100, 1 ), head, tail ) );
+  }
+}
+
+#ifdef VIAME_ENABLE_OPENCV
+TEST_F( measurement_utilities_test, segment_refinement_uses_rectification_and_triangulation )
+{
+  map_keypoints_to_camera_settings settings;
+  settings.refine_disparity_segment = true;
+  settings.refine_keypoints_disparity_window = 0;
+  settings.disparity_segment_max_error = 0.01;
+  utilities->configure( settings );
+  utilities->compute_rectification_maps( *left_cam, *right_cam, cv::Size( 1280, 720 ) );
+  kv::image_of< float > disparity( 1280, 720 );
+  for( unsigned y = 0; y < 720; ++y )
+  {
+    for( unsigned x = 0; x < 1280; ++x )
+    {
+      disparity( x, y ) = 100 - 0.25 * ( static_cast< double >( x ) - 640 );
+    }
+  }
+  const kv::vector_3d head3d( 0, 0, 1 ), tail3d( 0.4, 0, 2 );
+  const auto head = left_cam->project( head3d );
+  const auto tail = left_cam->project( tail3d );
+  kv::vector_2d rh, rt;
+  ASSERT_TRUE( utilities->refine_right_segment_with_disparity(
+    std::make_shared< kv::simple_image_container >( disparity ),
+    head, tail, *right_cam, rh, rt ) );
+  const auto measured = compute_stereo_measurement(
+    *left_cam, *right_cam, head, rh, tail, rt );
+  EXPECT_NEAR( measured.length, ( tail3d - head3d ).norm(), 1e-6 );
+  EXPECT_NEAR( measured.rms, 0, 1e-6 );
+}
+#endif


### PR DESCRIPTION
Adds robust head-tail disparity fitting to the existing `compute_measurements` process. This is an alternative to #288 for comparison; #288 is unchanged and its original head is also saved as `backup/pr-288-before-shared-measurement-20260910`.

The shared process samples disparity along the annotated segment, rejects invalid samples and outliers, and fits disparity versus image position before triangulating endpoints. This avoids fitting XYZ coordinates against image interpolation fractions, which biases lengths under perspective. It reuses existing stereo track association, rectification, output writers, and track-length aggregation rather than introducing another Python process. Rejected frames do not replace prior valid track measurements with zero.

- Adds `stereo_measure_current_annots_sgbm.pipe`, using SGBM/WLS and robust refinement.
- Enables the new refinement only in the SGBM pipeline. Foundation Stereo pipeline files and default sampling behavior remain unchanged.
- Validates sample counts, outlier limits, and residual thresholds. Fits require at least three inliers, a strict majority, and support spanning half the segment.
- Uses correct pixel-stride addressing in the new segment mode. Retains legacy endpoint sampling outside that mode to avoid changing existing Foundation Stereo results; a broader sampler correction is outside this PR.
- Documents configuration, calibration units, and the straight-segment assumption.

Validation: compiled changed native sources and linked the core library and process plugin using the existing build configuration in an isolated output directory. All 58 measurement utility tests pass, including new perspective, outlier/missing-data, configuration, disparity-format, reversed-endpoint, rectification/triangulation, and legacy-sampling compatibility coverage. The new SGBM pipeline passes `viame pipeline check`. No full clean build, model-backed run, or before/after dataset comparison was performed.

